### PR TITLE
Fix missing forward slash in OSC messaging from color producer

### DIFF
--- a/core/producer/color/color_producer.cpp
+++ b/core/producer/color/color_producer.cpp
@@ -103,7 +103,7 @@ public:
 
 	draw_frame receive_impl() override
 	{
-		monitor_subject_ << monitor::message("color") % color_str_;
+		monitor_subject_ << monitor::message("/color") % color_str_;
 
 		return frame_;
 	}


### PR DESCRIPTION
Minor fix.  There was a missing forward slash for the /color message in OSC from the color producer.