### PR TITLE
Augment OSC data from ffmpeg

### DIFF
--- a/modules/ffmpeg/producer/audio/audio_decoder.cpp
+++ b/modules/ffmpeg/producer/audio/audio_decoder.cpp
@@ -170,6 +170,11 @@ public:
 		return L"[audio-decoder] " + u16(codec_context_->codec->long_name);
 	}
 
+	std::wstring print_codec() const
+	{
+		return u16(codec_context_->codec->long_name);
+	}
+
 	uint64_t ffmpeg_channel_layout() const
 	{
 		if (codec_context_->channel_layout == 0)
@@ -186,5 +191,6 @@ std::shared_ptr<core::mutable_audio_buffer> audio_decoder::poll() { return impl_
 int	audio_decoder::num_channels() const { return impl_->codec_context_->channels; }
 uint64_t audio_decoder::ffmpeg_channel_layout() const { return impl_->ffmpeg_channel_layout(); }
 std::wstring audio_decoder::print() const{return impl_->print();}
+std::wstring audio_decoder::print_codec() const { return impl_->print_codec(); }
 
 }}

--- a/modules/ffmpeg/producer/audio/audio_decoder.h
+++ b/modules/ffmpeg/producer/audio/audio_decoder.h
@@ -46,6 +46,7 @@ public:
 	uint64_t ffmpeg_channel_layout() const;
 
 	std::wstring print() const;
+	std::wstring print_codec() const;
 private:
 	struct implementation;
 	spl::shared_ptr<implementation> impl_;

--- a/modules/ffmpeg/producer/video/video_decoder.cpp
+++ b/modules/ffmpeg/producer/video/video_decoder.cpp
@@ -165,7 +165,7 @@ public:
 
 	std::wstring print_codec() const
 	{
-		return u16(codec_context_->codec->long_name) + L" " + u16(codec_context_->codec->profiles->name);
+			return u16(codec_context_->codec->long_name);
 	}
 };
 

--- a/modules/ffmpeg/producer/video/video_decoder.cpp
+++ b/modules/ffmpeg/producer/video/video_decoder.cpp
@@ -162,6 +162,11 @@ public:
 	{
 		return L"[video-decoder] " + u16(codec_context_->codec->long_name);
 	}
+
+	std::wstring print_codec() const
+	{
+		return u16(codec_context_->codec->long_name) + L" " + u16(codec_context_->codec->profiles->name);
+	}
 };
 
 video_decoder::video_decoder(const spl::shared_ptr<AVFormatContext>& context) : impl_(new implementation(context)){}
@@ -175,5 +180,6 @@ uint32_t video_decoder::nb_frames() const{return impl_->nb_frames();}
 uint32_t video_decoder::file_frame_number() const{return static_cast<uint32_t>(impl_->file_frame_number_);}
 bool	video_decoder::is_progressive() const{return impl_->is_progressive_;}
 std::wstring video_decoder::print() const{return impl_->print();}
+std::wstring video_decoder::print_codec() const { return impl_->print_codec(); }
 
 }}

--- a/modules/ffmpeg/producer/video/video_decoder.h
+++ b/modules/ffmpeg/producer/video/video_decoder.h
@@ -56,6 +56,7 @@ public:
 	bool						is_progressive() const;
 
 	std::wstring				print() const;
+	std::wstring				print_codec() const;
 
 private:
 	struct implementation;


### PR DESCRIPTION
This adds more information to the OSC data sent from the ffmpeg producer.

The following has been added:

/file/clip
Data: [0] current frame count [1] duration with seek [2] current frame from first frame [3] total frames
(Example: LOAD 1-100 500FRAMEVIDEOFILE SEEK 100 LENGTH 50 would translate to: [0]=0 [1]=50 [2]=100 [3]=500)

/file/markers
Data: [0] number of first frame in relation to file [1] number of last frame in relation to file
(E.g. LOAD 1-100 500FRAMEVIDEOFILE SEEK 100 LENGTH 50 would be: [0]=500 [1]=560)

/file/channels
Data: [0] number of audio channels

/file/videocodec
Data: [0] The video codec of the loaded file. E.g. "MPEG-2 video 4:2:2"

/file/audiocodec
Data: [0] The audio codec of the loaded file. E.g. "PCM signed 16-bit little-endian"

/file/info
Data: [0] The resolution and framerate of the loaded file along with interlaced/progressive indiciator.  E.g. "1920x1080i50.00"