### PR TITLE
Feature: psd producer stability and text masks

### DIFF
--- a/build-scripts/build-windows.bat
+++ b/build-scripts/build-windows.bat
@@ -26,8 +26,8 @@ cmake -G "Visual Studio 14 2015" -A x64 .. || goto :error
 
 :: Build with MSBuild
 echo Building...
-msbuild "CasparCG Server.sln" /t:Clean /p:Configuration=RelWithDebInfo || goto :error
-msbuild "CasparCG Server.sln" /p:Configuration=RelWithDebInfo /m:%BUILD_PARALLEL_THREADS% || goto :error
+msbuild "CasparCG Server.sln" /t:Clean /p:Configuration=Release || goto :error
+msbuild "CasparCG Server.sln" /p:Configuration=Release /m:%BUILD_PARALLEL_THREADS% || goto :error
 
 :: Create server folder to later zip
 set SERVER_FOLDER=CasparCG Server
@@ -44,8 +44,8 @@ copy ..\deploy\general\CasparCG_Server_2.0-brochure.pdf "%SERVER_FOLDER%" || got
 :: Copy binaries
 echo Copying binaries...
 copy shell\*.dll "%SERVER_FOLDER%\server" || goto :error
-copy shell\RelWithDebInfo\casparcg.exe "%SERVER_FOLDER%\server" || goto :error
-copy shell\RelWithDebInfo\casparcg.pdb "%SERVER_FOLDER%\server" || goto :error
+copy shell\Release\casparcg.exe "%SERVER_FOLDER%\server" || goto :error
+copy shell\Release\casparcg.pdb "%SERVER_FOLDER%\server" || goto :error
 copy ..\shell\casparcg_auto_restart.bat "%SERVER_FOLDER%\server" || goto :error
 copy shell\casparcg.config "%SERVER_FOLDER%\server" || goto :error
 copy shell\*.ttf "%SERVER_FOLDER%\server" || goto :error

--- a/build-scripts/build-windows.bat
+++ b/build-scripts/build-windows.bat
@@ -45,7 +45,7 @@ copy ..\deploy\general\CasparCG_Server_2.0-brochure.pdf "%SERVER_FOLDER%" || got
 echo Copying binaries...
 copy shell\*.dll "%SERVER_FOLDER%\server" || goto :error
 copy shell\Release\casparcg.exe "%SERVER_FOLDER%\server" || goto :error
-copy shell\Release\casparcg.pdb "%SERVER_FOLDER%\server" || goto :error
+REM copy shell\Release\casparcg.pdb "%SERVER_FOLDER%\server" || goto :error
 copy ..\shell\casparcg_auto_restart.bat "%SERVER_FOLDER%\server" || goto :error
 copy shell\casparcg.config "%SERVER_FOLDER%\server" || goto :error
 copy shell\*.ttf "%SERVER_FOLDER%\server" || goto :error

--- a/core/frame/geometry.h
+++ b/core/frame/geometry.h
@@ -33,7 +33,8 @@ public:
 	enum class geometry_type
 	{
 		quad,
-		quad_list
+		quad_list,
+		quad_list_croppable
 	};
 
 	struct coord

--- a/core/producer/cg_proxy.cpp
+++ b/core/producer/cg_proxy.cpp
@@ -372,9 +372,11 @@ public:
 	{
 		auto& command = params.at(0);
 
-		if (command == L"play()")
+		if (command == L"play()") {
 			proxy_->play(0);
-		else if (command == L"stop()")
+			// Flash doesnt accept update until play, so send an extra update after play to be safe
+			proxy_->update(0, template_data_xml_.get());
+		}  else if (command == L"stop()")
 			proxy_->stop(0, 0);
 		else if (command == L"next()")
 			proxy_->next(0);

--- a/core/producer/cg_proxy.cpp
+++ b/core/producer/cg_proxy.cpp
@@ -43,6 +43,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/optional.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <future>
@@ -321,19 +322,22 @@ class cg_proxy_as_producer : public frame_producer
 
 	std::map<std::wstring, std::shared_ptr<core::variable>>	variables_;
 	std::vector<std::wstring>								variable_names_;
+	bool													template_data_as_json_;
 	core::binding<std::wstring>								template_data_xml_						{ [=] { return generate_template_data_xml(); } };
 	std::shared_ptr<void>									template_data_change_subscription_;
-	bool													is_playing_								= false;
 public:
 	cg_proxy_as_producer(
 			spl::shared_ptr<frame_producer> producer,
 			spl::shared_ptr<cg_proxy> proxy,
 			const std::wstring& template_name,
+			const bool autoplay,
+			const bool data_as_json,
 			const std::vector<std::wstring>& parameter_specification)
 		: producer_(std::move(producer))
 		, proxy_(std::move(proxy))
 		, template_name_(std::move(template_name))
 		, producer_has_its_own_variables_defined_(!producer_->get_variables().empty())
+		, template_data_as_json_(data_as_json)
 	{
 		if (parameter_specification.size() % 2 != 0)
 			CASPAR_THROW_EXCEPTION(user_error() << msg_info("Parameter specification must be a sequence of type and parameter name pairs"));
@@ -356,9 +360,10 @@ public:
 
 		template_data_change_subscription_ = template_data_xml_.on_change([=]
 		{
-			if (is_playing_)
-				proxy_->update(0, template_data_xml_.get());
+			proxy_->update(0, template_data_xml_.get());
 		});
+
+		proxy_->add(0, template_name_, autoplay, L"", template_data_xml_.get());
 	}
 
 	// frame_producer
@@ -368,10 +373,7 @@ public:
 		auto& command = params.at(0);
 
 		if (command == L"play()")
-		{
-			proxy_->add(0, template_name_, true, L"", template_data_xml_.get());
-			is_playing_ = true;
-		}
+			proxy_->play(0);
 		else if (command == L"stop()")
 			proxy_->stop(0, 0);
 		else if (command == L"next()")
@@ -424,6 +426,21 @@ public:
 private:
 	std::wstring generate_template_data_xml() const
 	{
+		if (template_data_as_json_)
+		{
+			boost::property_tree::wptree document;
+
+			for (auto& parameter_name : variable_names_)
+			{
+				document.add_child(parameter_name, boost::property_tree::wptree(variables_.at(parameter_name)->to_string()));
+			}
+
+			std::wstringstream json;
+			boost::property_tree::json_parser::write_json(json, document, false);
+			CASPAR_LOG(warning) << json.str();
+			return json.str();
+		}
+
 		boost::property_tree::wptree document;
 		boost::property_tree::wptree template_data;
 
@@ -462,16 +479,18 @@ private:
 void describe_cg_proxy_as_producer(core::help_sink& sink, const core::help_repository& repo)
 {
 	sink.short_description(L"Wraps any CG producer for compatibility with scene producer.");
-	sink.syntax(L"[CG] [template:string] {[param1_type:\"string\",\"number\"] [param1_name:string] {[param2_type:\"string\",\"number\"] [param2_name:string] {...}}}");
+	sink.syntax(L"[CG] [template:string] {[AUTOPLAY]} {[JSON]|[XML]} {[param1_type:\"string\",\"number\"] [param1_name:string] {[param2_type:\"string\",\"number\"] [param2_name:string] {...}}}");
 	sink.para()->text(L"Wraps any CG producer for compatibility with scene producer.");
 	sink.para()->text(L"It allows the user to specify what template parameters should be exposed to the parent scene. This is only required for Flash and HTML templates. PSD and Scene templates does this automatically.");
 	sink.para()->text(L"Examples only really usable from within the scene producer implementation:");
-	sink.example(L">> PLAY 1-10 [CG] folder/flas_template string f0 number f1");
+	sink.example(L">> PLAY 1-10 [CG] folder/flash_template string f0 number f1");
 	sink.para()->text(L"...followed by the scene producer setting variables causing the equivalent of a ")->code(L"CG ADD")->text(L". Then the following calls can be made:");
 	sink.example(L">> CALL 1-10 play()");
 	sink.example(L">> CALL 1-10 next()");
 	sink.example(L">> CALL 1-10 invoke() label");
 	sink.example(L">> CALL 1-10 stop()");
+	sink.para()->text(L"There is an optional autoplay parameter, and an optional parameter to specify what format to compile the variables data to (default xml):");
+	sink.example(L">> PLAY 1-10 [CG] folder/flash_template [AUTOPLAY] [JSON] string f0");
 }
 
 spl::shared_ptr<frame_producer> create_cg_proxy_as_producer(const core::frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params)
@@ -484,13 +503,19 @@ spl::shared_ptr<frame_producer> create_cg_proxy_as_producer(const core::frame_pr
 	auto proxy			= dependencies.cg_registry->get_proxy(producer);
 	auto params2		= params;
 
+	int skip_params = 2;
+	const bool autoplay = params.size() > skip_params && boost::iequals(params.at(skip_params), L"[AUTOPLAY]");
+	if (autoplay) skip_params++;
+	const bool json_data = params.size() > skip_params && boost::iequals(params.at(skip_params), L"[JSON]");
+	if (json_data || (params.size() > skip_params && boost::iequals(params.at(skip_params), L"[XML]"))) skip_params++;
+
 	if (proxy == cg_proxy::empty())
 		CASPAR_THROW_EXCEPTION(file_not_found() << msg_info(L"No template with name " + template_name + L" found"));
 
 	// Remove "[CG]" and template_name to only leave the parameter specification part
-	params2.erase(params2.begin(), params2.begin() + 2);
+	params2.erase(params2.begin(), params2.begin() + skip_params);
 
-	return spl::make_shared<cg_proxy_as_producer>(std::move(producer), std::move(proxy), template_name, params2);
+	return spl::make_shared<cg_proxy_as_producer>(std::move(producer), std::move(proxy), template_name, autoplay, json_data, params2);
 }
 
 void init_cg_proxy_as_producer(core::module_dependencies dependencies)

--- a/core/producer/cg_proxy.cpp
+++ b/core/producer/cg_proxy.cpp
@@ -358,12 +358,12 @@ public:
 				CASPAR_THROW_EXCEPTION(user_error() << msg_info("The type in a parameter specification must be either string or number"));
 		}
 
+		proxy_->add(0, template_name_, autoplay, L"", template_data_xml_.get());
+
 		template_data_change_subscription_ = template_data_xml_.on_change([=]
 		{
 			proxy_->update(0, template_data_xml_.get());
 		});
-
-		proxy_->add(0, template_name_, autoplay, L"", template_data_xml_.get());
 	}
 
 	// frame_producer

--- a/core/producer/color/color_producer.cpp
+++ b/core/producer/color/color_producer.cpp
@@ -33,17 +33,21 @@
 #include <core/help/help_repository.h>
 #include <core/help/help_sink.h>
 
-#include <common/except.h>
 #include <common/array.h>
 
 #include <boost/algorithm/string.hpp>
 
 #include <sstream>
+#include "core/producer/variable.h"
+#include "common/future.h"
 
 namespace caspar { namespace core {
 
 draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& frame_factory, const std::vector<uint32_t>& values)
 {
+	if (values.size() == 0)
+		return draw_frame::empty();
+
 	core::pixel_format_desc desc(pixel_format::bgra);
 	desc.planes.push_back(core::pixel_format_desc::plane(static_cast<int>(values.size()), 1, 4));
 	auto frame = frame_factory->create_frame(tag, desc, core::audio_channel_layout::invalid());
@@ -54,56 +58,85 @@ draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& f
 	return core::draw_frame(std::move(frame));
 }
 
-draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& frame_factory, uint32_t value)
+draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& frame_factory, const uint32_t value)
 {
-	std::vector<uint32_t> values = { value };
+	const std::vector<uint32_t> values = { value };
 
 	return create_color_frame(tag, frame_factory, values);
 }
 
-draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& frame_factory, const std::vector<std::wstring>& strs)
+std::vector<uint32_t> parse_colors(const std::wstring& raw_str)
 {
-	std::vector<uint32_t> values(strs.size());
+	std::vector<std::wstring> split;
+	boost::split(split, raw_str, boost::is_any_of(L" "));
 
-	for (int i = 0; i < values.size(); ++i)
+	std::vector<uint32_t> values;
+
+	for (int i = 0; i < split.size(); ++i)
 	{
-		if (!try_get_color(strs.at(i), values.at(i)))
-			CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Invalid color: " + strs.at(i)));
+		uint32_t val = 0;
+		if (try_get_color(split.at(i), val))
+			values.push_back(val);
 	}
 
-	return create_color_frame(tag, frame_factory, values);
+	return std::move(values);
 }
 
 class color_producer : public frame_producer_base
 {
-	monitor::subject		monitor_subject_;
+	monitor::subject			monitor_subject_;
 
-	const std::wstring		color_str_;
-	constraints				constraints_;
-	draw_frame				frame_;
+	constraints					constraints_;
+	draw_frame					frame_;
+	variable_impl<std::wstring>	colors_str_;
+	std::shared_ptr<void>		colors_str_subscription_;
 
 public:
-	color_producer(const spl::shared_ptr<core::frame_factory>& frame_factory, uint32_t value)
-		: color_str_(L"")
-		, constraints_(1, 1)
-		, frame_(create_color_frame(this, frame_factory, value))
+	color_producer(const spl::shared_ptr<core::frame_factory>& frame_factory, const std::wstring& colors, const long parent_width, const long parent_height)
+		: constraints_(parent_width, parent_height)
+		, frame_(draw_frame::empty())
 	{
+		colors_str_subscription_ = colors_str_.value().on_change([this, frame_factory]()
+		{
+			auto colors = parse_colors(colors_str_.value().get());
+			frame_ = create_color_frame(this, frame_factory, colors);
+
+		});
+		colors_str_.value().set(colors);
+
 		CASPAR_LOG(info) << print() << L" Initialized";
 	}
 
-	color_producer(const spl::shared_ptr<core::frame_factory>& frame_factory, const std::vector<std::wstring>& colors)
-		: color_str_(boost::join(colors, L", "))
-		, constraints_(static_cast<int>(colors.size()), 1)
-		, frame_(create_color_frame(this, frame_factory, colors))
+	std::future<std::wstring> call(const std::vector<std::wstring>& param) override
 	{
-		CASPAR_LOG(info) << print() << L" Initialized";
+		std::wstring result;
+		colors_str_.value().set(param.empty() ? L"" : param[0]);
+
+		return caspar::make_ready_future(std::move(result));
+	}
+
+	core::variable& get_variable(const std::wstring& name) override
+	{
+		if (name == L"color")
+			return colors_str_;
+
+		CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"color_producer does not have a variable called " + name));
+	}
+
+	const std::vector<std::wstring>& get_variables() const override
+	{
+		static const std::vector<std::wstring> vars = {
+			L"color",
+		};
+
+		return vars;
 	}
 
 	// frame_producer
 
 	draw_frame receive_impl() override
 	{
-		monitor_subject_ << monitor::message("/color") % color_str_;
+		monitor_subject_ << monitor::message("/color") % colors_str_.value().get();
 
 		return frame_;
 	}
@@ -115,7 +148,7 @@ public:
 
 	std::wstring print() const override
 	{
-		return L"color[" + color_str_ + L"]";
+		return L"color[" + colors_str_.value().get() + L"]";
 	}
 
 	std::wstring name() const override
@@ -127,7 +160,7 @@ public:
 	{
 		boost::property_tree::wptree info;
 		info.add(L"type", L"color");
-		info.add(L"color", color_str_);
+		info.add(L"color", colors_str_.value().get());
 		return info;
 	}
 
@@ -142,7 +175,7 @@ std::wstring get_hex_color(const std::wstring& str)
 	if(str.at(0) == '#')
 		return str.length() == 7 ? L"#FF" + str.substr(1) : str;
 
-	std::wstring col_str = boost::to_upper_copy(str);
+	const std::wstring col_str = boost::to_upper_copy(str);
 
 	if(col_str == L"EMPTY")
 		return L"#00000000";
@@ -197,6 +230,7 @@ void describe_color_producer(core::help_sink& sink, const core::help_repository&
 {
 	sink.short_description(L"Fills a layer with a solid color or a horizontal gradient.");
 	sink.syntax(
+		L"[COLOR] "
 		L"{#[argb_hex_value:string]}"
 		L",{#[rgb_hex_value:string]}"
 		L",{[named_color:EMPTY,BLACK,WHITE,RED,GREEN,BLUE,ORANGE,YELLOW,BROWN,GRAY,TEAL]} "
@@ -223,36 +257,35 @@ void describe_color_producer(core::help_sink& sink, const core::help_repository&
 		->strong(L"Note")->text(L" that it is important that all RGB values are multiplied with the alpha ")
 		->text(L"at all times, otherwise the compositing in the mixer will be incorrect.");
 	sink.para()->text(L"Solid color examples:");
-	sink.example(L">> PLAY 1-10 EMPTY", L"For a completely transparent frame.");
-	sink.example(L">> PLAY 1-10 #00000000", L"For an explicitly defined completely transparent frame.");
-	sink.example(L">> PLAY 1-10 #000000", L"For an explicitly defined completely opaque black frame.");
-	sink.example(L">> PLAY 1-10 RED", L"For a completely red frame.");
-	sink.example(L">> PLAY 1-10 #7F007F00",
+	sink.example(L">> PLAY 1-10 [COLOR] EMPTY", L"For a completely transparent frame.");
+	sink.example(L">> PLAY 1-10 [COLOR] #00000000", L"For an explicitly defined completely transparent frame.");
+	sink.example(L">> PLAY 1-10 [COLOR] #000000", L"For an explicitly defined completely opaque black frame.");
+	sink.example(L">> PLAY 1-10 [COLOR] RED", L"For a completely red frame.");
+	sink.example(L">> PLAY 1-10 [COLOR] #7F007F00",
 		L"For a completely green half transparent frame. "
 		L"Since the RGB part has been premultiplied with the A part this is 100% green.");
 	sink.para()->text(L"Horizontal gradient examples:");
-	sink.example(L">> PLAY 1-10 WHITE BLACK", L"For a gradient between white and black.");
-	sink.example(L">> PLAY 1-10 WHITE WHITE WHITE BLACK", L"For a gradient between white and black with the white part beings 3 times as long as the black part.");
+	sink.example(L">> PLAY 1-10 [COLOR] WHITE BLACK", L"For a gradient between white and black.");
+	sink.example(L">> PLAY 1-10 [COLOR] WHITE WHITE WHITE BLACK", L"For a gradient between white and black with the white part beings 3 times as long as the black part.");
 	sink.example(
-		L">> PLAY 1-10 RED EMPTY\n"
+		L">> PLAY 1-10 [COLOR] RED EMPTY\n"
 		L">> MIXER 1-10 ANCHOR 0.5 0.5\n"
 		L">> MIXER 1-10 FILL 0.5 0.5 2 2\n"
 		L">> MIXER 1-10 ROTATION 45",
 		L"For a 45 degree gradient covering the screen.");
 }
 
-spl::shared_ptr<frame_producer> create_color_producer(const spl::shared_ptr<frame_factory>& frame_factory, uint32_t value)
+spl::shared_ptr<frame_producer> create_color_producer(const frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params)
 {
-	return spl::make_shared<color_producer>(frame_factory, value);
-}
-
-spl::shared_ptr<frame_producer> create_color_producer(const spl::shared_ptr<frame_factory>& frame_factory, const std::vector<std::wstring>& params)
-{
-	if(params.size() < 0)
+	if(params.size() == 0)
 		return core::frame_producer::empty();
 
+	int start_pos = 0;
+	if (params.size() > 1 && boost::iequals(params.at(0), L"[color]"))
+		start_pos = 1;
+
 	uint32_t value = 0;
-	if(!try_get_color(params.at(0), value))
+	if(!try_get_color(params.at(start_pos), value))
 		return core::frame_producer::empty();
 
 	std::vector<std::wstring> colors;
@@ -270,7 +303,8 @@ spl::shared_ptr<frame_producer> create_color_producer(const spl::shared_ptr<fram
             }
 	}
 
-	return spl::make_shared<color_producer>(frame_factory, colors);
+	auto colors_str = boost::join(colors, L" ");
+	return spl::make_shared<color_producer>(dependencies.frame_factory, colors_str, dependencies.format_desc.width, dependencies.format_desc.height);
 }
 
 }}

--- a/core/producer/color/color_producer.h
+++ b/core/producer/color/color_producer.h
@@ -34,9 +34,7 @@ namespace caspar { namespace core {
 bool try_get_color(const std::wstring& str, uint32_t& value);
 
 void describe_color_producer(core::help_sink& sink, const core::help_repository& repo);
-spl::shared_ptr<frame_producer> create_color_producer(const spl::shared_ptr<frame_factory>& frame_factory, uint32_t value);
-spl::shared_ptr<frame_producer> create_color_producer(const spl::shared_ptr<frame_factory>& frame_factory, const std::vector<std::wstring>& params);
+spl::shared_ptr<frame_producer> create_color_producer(const frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params);
 draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& frame_factory, uint32_t value);
-draw_frame create_color_frame(void* tag, const spl::shared_ptr<frame_factory>& frame_factory, const std::wstring& color);
 
 }}

--- a/core/producer/frame_producer.cpp
+++ b/core/producer/frame_producer.cpp
@@ -361,7 +361,7 @@ spl::shared_ptr<core::frame_producer> do_create_producer(const frame_producer_de
     });
 
     if (producer == frame_producer::empty())
-        producer = create_color_producer(dependencies.frame_factory, params);
+        producer = create_color_producer(dependencies, params);
 
     if (producer == frame_producer::empty())
         return producer;

--- a/core/producer/scene/expression_parser.cpp
+++ b/core/producer/scene/expression_parser.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 
 #include <boost/any.hpp>
+#include <boost/date_time.hpp>
 #include <boost/locale.hpp>
 
 #include <common/log.h>
@@ -214,6 +215,31 @@ boost::any create_length_function(const std::vector<boost::any>& params, const v
 	return str.transformed([](std::wstring v) { return static_cast<double>(v.length()); });
 }
 
+boost::any create_date_function(const std::vector<boost::any>& params, const variable_repository& var_repo)
+{
+	if (params.size() != 1 && params.size() != 2)
+		CASPAR_THROW_EXCEPTION(user_error()
+			<< msg_info(L"date() function requires one or two parameters: format, offset"));
+
+	auto str = require<std::wstring>(params.at(0));
+	variable& time_var = var_repo(L"system_time");
+
+	binding<double> offset;
+	if (params.size() > 1)
+		offset = require<double>(params.at(1));
+
+	return time_var.as<int64_t>().transformed([str, offset](int64_t v)
+	{
+		std::locale loc(std::wcout.getloc(), new boost::posix_time::wtime_facet(str.get().c_str()));
+		auto newtime = boost::posix_time::second_clock::universal_time() + boost::posix_time::milliseconds(static_cast<long>(offset.get() * 1000));
+
+		std::wstringstream wss;
+		wss.imbue(loc);
+		wss << newtime;
+		return static_cast<std::wstring>(wss.str());
+	});
+}
+
 boost::any parse_function(
 		const std::wstring& function_name,
 		std::wstring::const_iterator& cursor,
@@ -229,7 +255,8 @@ boost::any parse_function(
 		{ L"floor",		create_floor_function },
 		{ L"to_lower",	create_to_lower_function },
 		{ L"to_upper",	create_to_upper_function },
-		{ L"length",	create_length_function }
+		{ L"length",	create_length_function },
+		{ L"date",		create_date_function },
 	};
 
 	auto function = FUNCTIONS.find(function_name);
@@ -570,13 +597,17 @@ op parse_operator(std::wstring::const_iterator& cursor, const std::wstring& str)
 boost::any as_binding(const boost::any& value)
 {
 	// Wrap supported constants as bindings
-	if (is<double>(value))
+	if (is<int64_t>(value))
+		return binding<int64_t>(as<int64_t>(value));
+	else if (is<double>(value))
 		return binding<double>(as<double>(value));
 	else if (is<bool>(value))
 		return binding<bool>(as<bool>(value));
 	else if (is<std::wstring>(value))
 		return binding<std::wstring>(as<std::wstring>(value));
 	// Already one of the supported binding types
+	else if (is<binding<int64_t>>(value))
+		return as<binding<int64_t>>(value);
 	else if (is<binding<double>>(value))
 		return as<binding<double>>(value);
 	else if (is<binding<bool>>(value))

--- a/core/producer/scene/hotswap_producer.cpp
+++ b/core/producer/scene/hotswap_producer.cpp
@@ -21,6 +21,8 @@
 
 #include "../../StdAfx.h"
 
+#include <common/future.h>
+
 #include "hotswap_producer.h"
 
 #include "../frame_producer.h"
@@ -126,6 +128,16 @@ const std::vector<std::wstring>& hotswap_producer::get_variables() const
 binding<std::shared_ptr<frame_producer>>& hotswap_producer::producer()
 {
 	return impl_->producer;
+}
+
+std::future<std::wstring> hotswap_producer::call(const std::vector<std::wstring>& params)
+{
+	auto producer = impl_->producer.get();
+
+	if (producer)
+		return producer->call(params);
+	else
+		return frame_producer_base::call(params);
 }
 
 }}

--- a/core/producer/scene/hotswap_producer.h
+++ b/core/producer/scene/hotswap_producer.h
@@ -44,6 +44,7 @@ public:
 	monitor::subject&					monitor_output() override;
 	variable&							get_variable(const std::wstring& name) override;
 	const std::vector<std::wstring>&	get_variables() const override;
+	std::future<std::wstring> call(const std::vector<std::wstring>& params) override;
 
 	binding<std::shared_ptr<frame_producer>>& producer();
 private:

--- a/core/producer/scene/scene_producer.cpp
+++ b/core/producer/scene/scene_producer.cpp
@@ -234,6 +234,17 @@ struct scene_producer::impl
 		CASPAR_THROW_EXCEPTION(user_error() << msg_info(name + L" not found in scene"));
 	}
 
+	bool has_keyframe(void* timeline_identity, const int64_t frame_number)
+	{
+		for(auto& keyframe : timelines_[timeline_identity].keyframes)
+		{
+			if (keyframe.first == frame_number)
+				return true;
+		}
+
+		return false;
+	}
+
 	void store_keyframe(void* timeline_identity, const keyframe& k)
 	{
 		timelines_[timeline_identity].keyframes.insert(std::make_pair(k.destination_frame, k));
@@ -791,6 +802,11 @@ std::future<std::wstring> scene_producer::call(const std::vector<std::wstring>& 
 monitor::subject& scene_producer::monitor_output()
 {
 	return impl_->monitor_output();
+}
+
+bool scene_producer::has_keyframe(void* timeline_identity, const int64_t k)
+{
+	return impl_->has_keyframe(timeline_identity, k);
 }
 
 void scene_producer::store_keyframe(void* timeline_identity, const keyframe& k)

--- a/core/producer/scene/scene_producer.cpp
+++ b/core/producer/scene/scene_producer.cpp
@@ -296,6 +296,11 @@ struct scene_producer::impl
 		task_subscriptions_.push_back(std::move(subscription));
 	}
 
+	bool has_variable(const std::wstring& name)
+	{
+		return variables_.find(name) != variables_.end();
+	}
+
 	core::variable& get_variable(const std::wstring& name)
 	{
 		auto found = variables_.find(name);
@@ -845,6 +850,10 @@ void scene_producer::add_task(binding<bool> when, std::function<void ()> task)
 	impl_->add_task(std::move(when), std::move(task));
 }
 
+bool scene_producer::has_variable(const std::wstring& name)
+{
+	return impl_->has_variable(name);
+}
 core::variable& scene_producer::get_variable(const std::wstring& name)
 {
 	return impl_->get_variable(name);

--- a/core/producer/scene/scene_producer.cpp
+++ b/core/producer/scene/scene_producer.cpp
@@ -610,7 +610,7 @@ struct scene_producer::impl
 	{
 		for (int i = 0; i + 1 < params.size(); i += 2)
 		{
-			auto found = variables_.find(boost::to_lower_copy(params.at(i)));
+			auto found = variables_.find(params.at(i));
 
 			if (found != variables_.end() && found->second->is_public())
 				found->second->from_string(params.at(i + 1));

--- a/core/producer/scene/scene_producer.h
+++ b/core/producer/scene/scene_producer.h
@@ -189,6 +189,12 @@ public:
 			return;
 		}
 
+		if (has_keyframe(to_affect.identity(), at_frame))
+		{
+			CASPAR_LOG(warning) << "Found duplicate keyframe " << at_frame;
+			return;
+		}
+
 		tweener tween(easing);
 		keyframe k(at_frame);
 
@@ -233,6 +239,12 @@ public:
 	template<typename T>
 	void add_keyframe(binding<T>& to_affect, const binding<T>& set_value, int64_t at_frame)
 	{
+		if (has_keyframe(to_affect.identity(), at_frame))
+		{
+			CASPAR_LOG(warning) << "Found duplicate keyframe " << at_frame;
+			return;
+		}
+
 		keyframe k(at_frame);
 
 		k.on_destination_frame = [=]() mutable
@@ -249,6 +261,7 @@ public:
 	core::variable& get_variable(const std::wstring& name) override;
 	const std::vector<std::wstring>& get_variables() const override;
 private:
+	bool has_keyframe(void* timeline_identity, const int64_t k);
 	void store_keyframe(void* timeline_identity, const keyframe& k);
 	void store_variable(
 			const std::wstring& name, const std::shared_ptr<core::variable>& var);

--- a/core/producer/scene/scene_producer.h
+++ b/core/producer/scene/scene_producer.h
@@ -258,6 +258,7 @@ public:
 	void add_mark(int64_t at_frame, mark_action action, const std::wstring& label);
 	void add_task(binding<bool> when, std::function<void ()> task);
 
+	bool has_variable(const std::wstring& name);
 	core::variable& get_variable(const std::wstring& name) override;
 	const std::vector<std::wstring>& get_variables() const override;
 private:

--- a/core/producer/text/text_producer.cpp
+++ b/core/producer/text/text_producer.cpp
@@ -254,7 +254,7 @@ public:
 		text::string_metrics metrics;
 		font_.set_tracking(tracking_.value().get());
 
-		std::vector<text::text_char> vertex_stream = font_.create_vertex_stream(str, x_, y_, parent_width_, parent_height_, standalone_, &metrics, shear_.value().get());
+		std::vector<text::text_char> vertex_stream = font_.create_vertex_stream(str, x_, y_, parent_width_, parent_height_, !standalone_, &metrics, shear_.value().get());
 
 		std::vector<draw_frame> res;
 		for (auto it = atlas_frames_.begin(); it != atlas_frames_.end(); ++it)

--- a/core/producer/text/text_producer.h
+++ b/core/producer/text/text_producer.h
@@ -46,8 +46,8 @@ class text_producer : public frame_producer_base
 {
 public:
 	text_producer(const spl::shared_ptr<frame_factory>& frame_factory, int x, int y, const std::wstring& str,
-		text::text_info& text_info, long parent_width, long parent_height, bool standalone);
-	static spl::shared_ptr<text_producer> create(const spl::shared_ptr<frame_factory>& frame_factory, int x, int y, const std::wstring& str, text::text_info& text_info, long parent_width, long parent_height, bool standalone = false);
+		text::text_info& text_info, long parent_width, long parent_height, bool standalone, bool croppable);
+	static spl::shared_ptr<text_producer> create(const spl::shared_ptr<frame_factory>& frame_factory, int x, int y, const std::wstring& str, text::text_info& text_info, long parent_width, long parent_height, bool standalone = false, bool croppable = false);
 
 	draw_frame receive_impl() override;
 	std::future<std::wstring> call(const std::vector<std::wstring>& param) override;

--- a/core/producer/text/utils/texture_atlas.h
+++ b/core/producer/text/utils/texture_atlas.h
@@ -67,32 +67,37 @@
 
 namespace caspar { namespace core { namespace text {
 
-struct rect
+struct atlas_rect
 {
+	int index;
 	int x;
 	int y;
 	int width;
 	int height;
 };
 
-class texture_atlas
+// How much each char stored in the atlas is padded by. This is to ensure that edges arent clipped during rendering, and that no bleed from adjacent chars occurs
+#define CHAR_PADDING 5
+
+class texture_atlas_set
 {
 public:
-	texture_atlas(const size_t w, const size_t h, const size_t d);
+	texture_atlas_set(const size_t w, const size_t h, const size_t d);
 
-	rect get_region(int width, int height) const;
-	void set_region(const size_t x, const size_t y, const size_t width, const size_t height, const unsigned char *data, const size_t stride, const color<double>& col);
-	void clear();
+	atlas_rect get_region(int width, int height) const;
+	void set_region(const atlas_rect rect, const size_t width, const size_t height, const unsigned char *data, const size_t stride, const color<double>& col);
 
 	size_t depth() const;
 	size_t width() const;
 	size_t height() const;
 
-	const uint8_t* data() const;
+	size_t size() const;
+	const uint8_t* data(int index) const;
 
 private:
 	struct impl;
 	caspar::spl::shared_ptr<impl> impl_;
+
 };
 
 }}}

--- a/core/producer/text/utils/texture_font.cpp
+++ b/core/producer/text/utils/texture_font.cpp
@@ -40,21 +40,18 @@ private:
 	texture_atlas_set				atlas_set_;
 	double							size_;
 	double							tracking_;
-	bool							normalize_;
 	std::map<int, glyph_info>		glyphs_;
 	std::vector<unicode_block>		loaded_blocks_;
 	std::wstring					name_;
-	bool							normalize_coordinates_;
 	color<double>					col_;
 
 public:
-	impl(texture_atlas_set& atlas_set, const text_info& info, const bool normalize_coordinates, color<double>& col)
+	impl(texture_atlas_set& atlas_set, const text_info& info, color<double>& col)
 		: face_(get_new_face(u8(info.font_file), u8(info.font)))
 		, atlas_set_(atlas_set)
 		, size_(info.size)
 		, tracking_(info.size*info.tracking/1000.0)
-		, normalize_(normalize_coordinates)
-		, name_(info.font), normalize_coordinates_(normalize_coordinates)
+		, name_(info.font)
 		, col_(col)
 	{
 		if (FT_Set_Char_Size(face_.get(), static_cast<FT_F26Dot6>(size_*64), 0, 72, 72))
@@ -123,7 +120,7 @@ public:
 		}
 	}
 
-	std::vector<text_char> create_vertex_stream(const std::wstring& str, const int x, const int y, const int parent_width, const int parent_height, string_metrics* metrics, double shear)
+	std::vector<text_char> create_vertex_stream(const std::wstring& str, const int x, const int y, const int parent_width, const int parent_height, bool normalize, string_metrics* metrics, double shear)
 	{
 		std::vector<text_char> result;
 		result.resize(str.length());
@@ -211,7 +208,7 @@ public:
 			previous = glyph_index;
 		}
 
-		if(normalize_)
+		if(normalize)
 		{
 			const auto ratio_x = parent_width / (pos_x - tracking_ - x);
 			const auto ratio_y = parent_height / static_cast<double>(maxHeight);
@@ -252,10 +249,10 @@ public:
 	}
 };
 
-texture_font::texture_font(texture_atlas_set& atlas, const text_info& info, const bool normalize_coordinates, color<double>& col) : impl_(new impl(atlas, info, normalize_coordinates, col)) {}
+texture_font::texture_font(texture_atlas_set& atlas, const text_info& info, color<double>& col) : impl_(new impl(atlas, info, col)) {}
 bool texture_font::load_blocks_for_string(const std::wstring str) { return impl_->load_blocks_for_string(str); }
 void texture_font::set_tracking(const double tracking) { impl_->set_tracking(tracking); }
-std::vector<text_char> texture_font::create_vertex_stream(const std::wstring& str, const int x, const int y, const int parent_width, const int parent_height, string_metrics* metrics, const double shear) { return impl_->create_vertex_stream(str, x, y, parent_width, parent_height, metrics, shear); }
+std::vector<text_char> texture_font::create_vertex_stream(const std::wstring& str, const int x, const int y, const int parent_width, const int parent_height, bool normalize, string_metrics* metrics, const double shear) { return impl_->create_vertex_stream(str, x, y, parent_width, parent_height, normalize, metrics, shear); }
 std::wstring texture_font::get_name() const { return impl_->get_name(); }
 double texture_font::get_size() const { return impl_->get_size(); }
 

--- a/core/producer/text/utils/texture_font.cpp
+++ b/core/producer/text/utils/texture_font.cpp
@@ -15,7 +15,7 @@ namespace caspar { namespace core { namespace text {
 struct unicode_range
 {
 	unicode_range() : first(0), last(0) {}
-	unicode_range(int f, int l) : first(f), last(l) {}
+	unicode_range(const int f, const int l) : first(f), last(l) {}
 
 	int first;
 	int last;
@@ -23,96 +23,112 @@ struct unicode_range
 
 unicode_range get_range(unicode_block block);
 
-
 struct texture_font::impl
 {
 private:
 	struct glyph_info
 	{
-		glyph_info(int w, int h, double l, double t, double r, double b) : width(w), height(h), left(l), top(t), right(r), bottom(b)
+		glyph_info(int i, int w, int h, double l, double t, double r, double b) : index(i), width(w), height(h), left(l), top(t), right(r), bottom(b)
 		{}
 
+		int index;
 		double left, top, right, bottom;
 		int width, height;
 	};
 
 	spl::shared_ptr<FT_FaceRec_>	face_;
-	texture_atlas					atlas_;
+	texture_atlas_set				atlas_set_;
 	double							size_;
 	double							tracking_;
 	bool							normalize_;
 	std::map<int, glyph_info>		glyphs_;
+	std::vector<unicode_block>		loaded_blocks_;
 	std::wstring					name_;
+	bool							normalize_coordinates_;
+	color<double>					col_;
 
 public:
-	impl(texture_atlas& atlas, const text_info& info, bool normalize_coordinates)
+	impl(texture_atlas_set& atlas_set, const text_info& info, const bool normalize_coordinates, color<double>& col)
 		: face_(get_new_face(u8(info.font_file), u8(info.font)))
-		, atlas_(atlas)
+		, atlas_set_(atlas_set)
 		, size_(info.size)
 		, tracking_(info.size*info.tracking/1000.0)
 		, normalize_(normalize_coordinates)
-		, name_(info.font)
+		, name_(info.font), normalize_coordinates_(normalize_coordinates)
+		, col_(col)
 	{
 		if (FT_Set_Char_Size(face_.get(), static_cast<FT_F26Dot6>(size_*64), 0, 72, 72))
 			CASPAR_THROW_EXCEPTION(expected_freetype_exception() << msg_info("Failed to set font size"));
 	}
 
-	void set_tracking(double tracking)
+	void set_tracking(const double tracking)
 	{
 		tracking_ = size_ * tracking / 1000.0;
 	}
 
-	int count_glyphs_in_range(unicode_block block)
+	void load_block_for_char(const int ch)
 	{
-		unicode_range range = get_range(block);
-
-		//TODO: extract info from freetype
-
-		//very pesimistic, assumes a glyph for each charcode
-		return range.last - range.first;
-	}
-
-	void load_glyphs(unicode_block block, const color<double>& col)
-	{
-		int flags = FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_NORMAL;
-		unicode_range range = get_range(block);
-
-		for(int i = range.first; i <= range.last; ++i)
+		for (int bl = static_cast<int>(unicode_block::Basic_Latin); bl != static_cast<int>(unicode_block::Supplementary_Private_Use_Area_B); ++bl)
 		{
-			FT_UInt glyph_index = FT_Get_Char_Index(face_.get(), i);
-			if(!glyph_index)	//ignore codes that doesn't have a glyph for now. Might want to map these to a special glyph later.
-				continue;
-
-			FT_Error err = FT_Load_Glyph(face_.get(), glyph_index, flags);
-			if(err) continue;	//igonore glyphs that fail to load
-
-			const FT_Bitmap& bitmap = face_->glyph->bitmap;	//shorthand notation
-
-			auto region = atlas_.get_region(bitmap.width+1, bitmap.rows+1);
-			if(region.x < 0)
-			{
-				//the glyph doesn't fit in the texture-atlas. ignore it for now.
-				//we might want to restart with a bigger atlas in the future
-				continue;
+			const unicode_block block = static_cast<unicode_block>(bl);
+			const unicode_range range = get_range(block);
+			if (ch >= range.first && ch <= range.last) {
+				load_glyphs(block, range);
+				return;
 			}
-
-			atlas_.set_region(region.x, region.y, bitmap.width, bitmap.rows, bitmap.buffer, bitmap.pitch, col);
-			glyphs_.insert(std::pair<int, glyph_info>(i, glyph_info(bitmap.width, bitmap.rows,
-										region.x / static_cast<double>(atlas_.width()),
-										region.y / static_cast<double>(atlas_.height()),
-										(region.x + bitmap.width) / static_cast<double>(atlas_.width()),
-										(region.y + bitmap.rows) / static_cast<double>(atlas_.height()))));
 		}
 	}
 
-	std::vector<frame_geometry::coord> create_vertex_stream(const std::wstring& str, int x, int y, int parent_width, int parent_height, string_metrics* metrics, double shear)
+	bool load_blocks_for_string(const std::wstring str)
 	{
-		//TODO: detect glyphs that aren't in the atlas and load them (and maybe that entire unicode_block on the fly
+		const size_t loaded_count = loaded_blocks_.size();
 
-		std::vector<frame_geometry::coord> result;
-		result.resize(4 * str.length());
+		for (auto& ch: str)
+			load_block_for_char(ch);
 
-		bool use_kerning = (face_->face_flags & FT_FACE_FLAG_KERNING) == FT_FACE_FLAG_KERNING;
+		return loaded_blocks_.size() > loaded_count;
+	}
+	
+	void load_glyphs(const unicode_block block, const unicode_range range)
+	{
+		if (std::find(loaded_blocks_.begin(), loaded_blocks_.end(), block) != loaded_blocks_.end())
+			return;
+		loaded_blocks_.push_back(block);
+
+		for (int i = range.first; i <= range.last; ++i)
+		{
+			const FT_UInt glyph_index = FT_Get_Char_Index(face_.get(), i);
+			if (!glyph_index)	//ignore codes that doesn't have a glyph for now. Might want to map these to a special glyph later.
+				continue;
+
+			const int flags = FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_NORMAL;
+			const FT_Error err = FT_Load_Glyph(face_.get(), glyph_index, flags);
+			if (err) continue;	//igonore glyphs that fail to load
+
+			const FT_Bitmap& bitmap = face_->glyph->bitmap;	//shorthand notation
+
+			const atlas_rect region = atlas_set_.get_region(bitmap.width + CHAR_PADDING * 2, bitmap.rows + CHAR_PADDING * 2);
+			if (region.x < 0 || region.index < 0)
+			{
+				// glyph was too big for atlas. ignore it for now.
+				continue;
+			}
+
+			atlas_set_.set_region(region, bitmap.width, bitmap.rows, bitmap.buffer, bitmap.pitch, col_);
+			glyphs_.insert(std::pair<int, glyph_info>(i, glyph_info(region.index, bitmap.width, bitmap.rows,
+				region.x / static_cast<double>(atlas_set_.width()),
+				region.y / static_cast<double>(atlas_set_.height()),
+				(region.x + region.width) / static_cast<double>(atlas_set_.width()),
+				(region.y + region.height) / static_cast<double>(atlas_set_.height()))));
+		}
+	}
+
+	std::vector<text_char> create_vertex_stream(const std::wstring& str, const int x, const int y, const int parent_width, const int parent_height, string_metrics* metrics, double shear)
+	{
+		std::vector<text_char> result;
+		result.resize(str.length());
+
+		const bool use_kerning = (face_->face_flags & FT_FACE_FLAG_KERNING) == FT_FACE_FLAG_KERNING;
 		int index = 0;
 		FT_UInt previous = 0;
 		double pos_x = static_cast<double>(x);
@@ -124,90 +140,93 @@ public:
 
 		for (auto it = str.begin(), end = str.end(); it != end; ++it, ++index)
 		{
-			auto glyph_it = glyphs_.find(*it);
-			if (glyph_it != glyphs_.end())
+			const auto glyph_it = glyphs_.find(*it);
+			if (glyph_it == glyphs_.end())
+				continue;
+
+			const glyph_info& coords = glyph_it->second;
+				
+			const FT_UInt glyph_index = FT_Get_Char_Index(face_.get(), (*it));
+
+			if(use_kerning && previous && glyph_index)
 			{
-				const glyph_info& coords = glyph_it->second;
+				FT_Vector delta;
+				FT_Get_Kerning(face_.get(), previous, glyph_index, FT_KERNING_DEFAULT, &delta);
 
-				FT_UInt glyph_index = FT_Get_Char_Index(face_.get(), (*it));
-
-				if(use_kerning && previous && glyph_index)
-				{
-					FT_Vector delta;
-					FT_Get_Kerning(face_.get(), previous, glyph_index, FT_KERNING_DEFAULT, &delta);
-
-					pos_x += delta.x / 64.0;
-				}
-
-				FT_Load_Glyph(face_.get(), glyph_index, FT_LOAD_NO_BITMAP | FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_NORMAL);
-
-				double left = (pos_x + face_->glyph->metrics.horiBearingX / 64.0) / parent_width;
-				double right = ((pos_x + face_->glyph->metrics.horiBearingX / 64.0) + coords.width) / parent_width;
-
-				double top = (pos_y - face_->glyph->metrics.horiBearingY/64.0) / parent_height;
-				double bottom = ((pos_y - face_->glyph->metrics.horiBearingY / 64.0) + coords.height) / parent_height;
-
-				auto ul_index = index * 4;
-				auto ur_index = ul_index + 1;
-				auto lr_index = ul_index + 2;
-				auto ll_index = ul_index + 3;
-
-				//vertex 1 upper left
-				result[ul_index].vertex_x = left;	//vertex.x
-				result[ul_index].vertex_y	= top;		  		//vertex.y
-				result[ul_index].texture_x	= coords.left;		//texcoord.r
-				result[ul_index].texture_y	= coords.top; 		//texcoord.s
-
-				//vertex 2 upper right
-				result[ur_index].vertex_x = right;	//vertex.x
-				result[ur_index].vertex_y	= top;		   		//vertex.y
-				result[ur_index].texture_x	= coords.right;		//texcoord.r
-				result[ur_index].texture_y	= coords.top;  		//texcoord.s
-
-				//vertex 3 lower right
-				result[lr_index].vertex_x	= right;	//vertex.x
-				result[lr_index].vertex_y	= bottom;	   			//vertex.y
-				result[lr_index].texture_x	= coords.right;			//texcoord.r
-				result[lr_index].texture_y	= coords.bottom;		//texcoord.s
-
-				//vertex 4 lower left
-				result[ll_index].vertex_x	= left;	//vertex.x
-				result[ll_index].vertex_y	= bottom;				//vertex.y
-				result[ll_index].texture_x	= coords.left;			//texcoord.r
-				result[ll_index].texture_y	= coords.bottom;		//texcoord.s
-
-				int bearingY = face_->glyph->metrics.horiBearingY >> 6;
-
-				if(bearingY > maxBearingY)
-					maxBearingY = bearingY;
-
-				int protrudeUnderY = coords.height - bearingY;
-
-				if (protrudeUnderY > maxProtrudeUnderY)
-					maxProtrudeUnderY = protrudeUnderY;
-
-				if (maxBearingY + maxProtrudeUnderY > maxHeight)
-					maxHeight = maxBearingY + maxProtrudeUnderY;
-
-				pos_x += face_->glyph->advance.x / 64.0;
-				pos_x += tracking_;
-				previous = glyph_index;
+				pos_x += delta.x / 64.0;
 			}
-			else
-			{
-				//TODO: maybe we should try to load the glyph on the fly if it is missing.
-			}
+
+			FT_Load_Glyph(face_.get(), glyph_index, FT_LOAD_NO_BITMAP | FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_NORMAL);
+
+			const double left = (pos_x - CHAR_PADDING + face_->glyph->metrics.horiBearingX / 64.0) / parent_width;
+			const double right = ((pos_x + CHAR_PADDING + face_->glyph->metrics.horiBearingX / 64.0) + coords.width) / parent_width;
+
+			const double top = (pos_y - CHAR_PADDING - face_->glyph->metrics.horiBearingY/64.0) / parent_height;
+			const double bottom = ((pos_y + CHAR_PADDING - face_->glyph->metrics.horiBearingY / 64.0) + coords.height) / parent_height;
+				
+			text_char new_char;
+			new_char.atlas_index = coords.index;
+				
+			//vertex 1 upper left
+			new_char.ul_coord.vertex_x = left;	//vertex.x
+			new_char.ul_coord.vertex_y	= top;		  		//vertex.y
+			new_char.ul_coord.texture_x	= coords.left;		//texcoord.r
+			new_char.ul_coord.texture_y	= coords.top; 		//texcoord.s
+
+			//vertex 2 upper right
+			new_char.ur_coord.vertex_x = right;	//vertex.x
+			new_char.ur_coord.vertex_y	= top;		   		//vertex.y
+			new_char.ur_coord.texture_x	= coords.right;		//texcoord.r
+			new_char.ur_coord.texture_y	= coords.top;  		//texcoord.s
+
+			//vertex 3 lower right
+			new_char.lr_coord.vertex_x	= right;	//vertex.x
+			new_char.lr_coord.vertex_y	= bottom;	   			//vertex.y
+			new_char.lr_coord.texture_x	= coords.right;			//texcoord.r
+			new_char.lr_coord.texture_y	= coords.bottom;		//texcoord.s
+
+			//vertex 4 lower left
+			new_char.ll_coord.vertex_x	= left;	//vertex.x
+			new_char.ll_coord.vertex_y	= bottom;				//vertex.y
+			new_char.ll_coord.texture_x	= coords.left;			//texcoord.r
+			new_char.ll_coord.texture_y	= coords.bottom;		//texcoord.s
+
+			result[index] = new_char;
+
+			const int bearingY = face_->glyph->metrics.horiBearingY >> 6;
+
+			if(bearingY > maxBearingY)
+				maxBearingY = bearingY;
+
+			const int protrudeUnderY = coords.height - bearingY;
+
+			if (protrudeUnderY > maxProtrudeUnderY)
+				maxProtrudeUnderY = protrudeUnderY;
+
+			if (maxBearingY + maxProtrudeUnderY > maxHeight)
+				maxHeight = maxBearingY + maxProtrudeUnderY;
+
+			pos_x += face_->glyph->advance.x / 64.0;
+			pos_x += tracking_;
+			previous = glyph_index;
 		}
 
 		if(normalize_)
 		{
-			auto ratio_x = parent_width / (pos_x - tracking_ - x);
-			auto ratio_y = parent_height / static_cast<double>(maxHeight);
+			const auto ratio_x = parent_width / (pos_x - tracking_ - x);
+			const auto ratio_y = parent_height / static_cast<double>(maxHeight);
 
 			for (auto& coord : result)
 			{
-				coord.vertex_x *= ratio_x;
-				coord.vertex_y *= ratio_y;
+				// TODO - check this applies, now that coord is a struct
+				coord.ul_coord.vertex_x *= ratio_x;
+				coord.ul_coord.vertex_y *= ratio_y;
+				coord.ur_coord.vertex_x *= ratio_x;
+				coord.ur_coord.vertex_y *= ratio_y;
+				coord.lr_coord.vertex_x *= ratio_x;
+				coord.lr_coord.vertex_y *= ratio_y;
+				coord.ll_coord.vertex_x *= ratio_x;
+				coord.ll_coord.vertex_y *= ratio_y;
 			}
 		}
 
@@ -233,14 +252,14 @@ public:
 	}
 };
 
-texture_font::texture_font(texture_atlas& atlas, const text_info& info, bool normalize_coordinates) : impl_(new impl(atlas, info, normalize_coordinates)) {}
-void texture_font::load_glyphs(unicode_block range, const color<double>& col) { impl_->load_glyphs(range, col); }
-void texture_font::set_tracking(double tracking) { impl_->set_tracking(tracking); }
-std::vector<frame_geometry::coord> texture_font::create_vertex_stream(const std::wstring& str, int x, int y, int parent_width, int parent_height, string_metrics* metrics, double shear) { return impl_->create_vertex_stream(str, x, y, parent_width, parent_height, metrics, shear); }
+texture_font::texture_font(texture_atlas_set& atlas, const text_info& info, const bool normalize_coordinates, color<double>& col) : impl_(new impl(atlas, info, normalize_coordinates, col)) {}
+bool texture_font::load_blocks_for_string(const std::wstring str) { return impl_->load_blocks_for_string(str); }
+void texture_font::set_tracking(const double tracking) { impl_->set_tracking(tracking); }
+std::vector<text_char> texture_font::create_vertex_stream(const std::wstring& str, const int x, const int y, const int parent_width, const int parent_height, string_metrics* metrics, const double shear) { return impl_->create_vertex_stream(str, x, y, parent_width, parent_height, metrics, shear); }
 std::wstring texture_font::get_name() const { return impl_->get_name(); }
 double texture_font::get_size() const { return impl_->get_size(); }
 
-unicode_range get_range(unicode_block block)
+unicode_range get_range(const unicode_block block)
 {
 	switch(block)
 	{

--- a/core/producer/text/utils/texture_font.h
+++ b/core/producer/text/utils/texture_font.h
@@ -10,6 +10,15 @@
 
 namespace caspar { namespace core { namespace text {
 
+struct text_char
+{
+	int atlas_index;
+	frame_geometry::coord ul_coord;
+	frame_geometry::coord ur_coord;
+	frame_geometry::coord ll_coord;
+	frame_geometry::coord lr_coord;
+};
+
 class texture_atlas;
 enum class unicode_block;
 
@@ -20,10 +29,10 @@ class texture_font
 	const texture_font& operator=(const texture_font&);
 
 public:
-	texture_font(texture_atlas&, const text_info&, bool normalize_coordinates);
-	void load_glyphs(unicode_block block, const color<double>& col);
+	texture_font(texture_atlas_set&, const text_info&, bool normalize_coordinates, color<double>& col);
+	bool load_blocks_for_string(const std::wstring str);
 	void set_tracking(double tracking);
-	std::vector<frame_geometry::coord> create_vertex_stream(const std::wstring& str, int x, int y, int parent_width, int parent_height, string_metrics* metrics, double shear = 0.0);
+	std::vector<text_char> create_vertex_stream(const std::wstring& str, int x, int y, int parent_width, int parent_height, string_metrics* metrics, double shear = 0.0);
 	std::wstring get_name() const;
 	double get_size() const;
 

--- a/core/producer/text/utils/texture_font.h
+++ b/core/producer/text/utils/texture_font.h
@@ -29,10 +29,10 @@ class texture_font
 	const texture_font& operator=(const texture_font&);
 
 public:
-	texture_font(texture_atlas_set&, const text_info&, bool normalize_coordinates, color<double>& col);
+	texture_font(texture_atlas_set&, const text_info&, color<double>& col);
 	bool load_blocks_for_string(const std::wstring str);
 	void set_tracking(double tracking);
-	std::vector<text_char> create_vertex_stream(const std::wstring& str, int x, int y, int parent_width, int parent_height, string_metrics* metrics, double shear = 0.0);
+	std::vector<text_char> create_vertex_stream(const std::wstring& str, int x, int y, int parent_width, int parent_height, bool normalize_coordinates, string_metrics* metrics, double shear = 0.0);
 	std::wstring get_name() const;
 	double get_size() const;
 

--- a/core/producer/variable.h
+++ b/core/producer/variable.h
@@ -28,6 +28,7 @@
 
 #include <common/log.h>
 #include <common/except.h>
+#include <common/utf.h>
 
 #include "binding.h"
 
@@ -69,6 +70,10 @@ public:
 	template<typename T>
 	binding<T>& as()
 	{
+		if (!this->is<T>()) {
+			CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Unable to cast bind of type " + type_name() + L" to " + u16(std::string(typeid(T).name()))));
+		}
+
 		return dynamic_cast<variable_impl<T>&>(*this).value();
 	}
 
@@ -82,6 +87,7 @@ public:
 	virtual std::wstring to_string() const = 0;
 private:
 	virtual bool is(const std::type_info& type) const = 0;
+	virtual std::wstring type_name() const = 0;
 };
 
 template<typename T>
@@ -133,9 +139,12 @@ public:
 		return boost::lexical_cast<std::wstring>(value_.get());
 	}
 private:
-	virtual bool is(const std::type_info& type) const
+	bool is(const std::type_info& type) const override
 	{
 		return typeid(T) == type;
+	}
+	std::wstring type_name() const override {
+		return u16(std::string(typeid(T).name()));
 	}
 };
 

--- a/dependencies64/boost/boost/property_tree/detail/json_parser/standard_callbacks.hpp
+++ b/dependencies64/boost/boost/property_tree/detail/json_parser/standard_callbacks.hpp
@@ -129,6 +129,7 @@ namespace boost { namespace property_tree {
                 return new_tree();
             }
             assert(false);
+			throw(std::logic_error("reached passed assert!"));
         }
         string& new_value() {
             if (stack.empty()) return new_tree().data();

--- a/modules/html/producer/html_cg_proxy.cpp
+++ b/modules/html/producer/html_cg_proxy.cpp
@@ -80,7 +80,10 @@ void html_cg_proxy::next(int layer)
 
 void html_cg_proxy::update(int layer, const std::wstring& data)
 {
-	impl_->producer->call({ (boost::wformat(L"update(\"%1%\")") % boost::algorithm::replace_all_copy(boost::algorithm::trim_copy_if(data, boost::is_any_of(" \"")), "\"", "\\\"")).str() });
+	auto str = boost::algorithm::trim_copy_if(data, boost::is_any_of("\r\n \""));
+	str = boost::algorithm::replace_all_copy(str, "\\", "\\\\");
+	str = boost::algorithm::replace_all_copy(str, "\"", "\\\"");
+	impl_->producer->call({ (boost::wformat(L"update(\"%1%\")") % str).str() });
 }
 
 std::wstring html_cg_proxy::invoke(int layer, const std::wstring& label)

--- a/modules/image/producer/image_producer.cpp
+++ b/modules/image/producer/image_producer.cpp
@@ -134,8 +134,10 @@ struct image_producer : public core::frame_producer_base
 
 		std::copy_n(FreeImage_GetBits(bitmap.get()), frame.image_data().size(), frame.image_data().begin());
 		frame_ = core::draw_frame(std::move(frame));
-		constraints_.width.set(FreeImage_GetWidth(bitmap.get()));
-		constraints_.height.set(FreeImage_GetHeight(bitmap.get()));
+		if (!constraints_.width.bound())
+			constraints_.width.set(FreeImage_GetWidth(bitmap.get()));
+		if (!constraints_.height.bound())
+			constraints_.height.set(FreeImage_GetHeight(bitmap.get()));
 	}
 
 	std::future<std::wstring> call(const std::vector<std::wstring>& param) override

--- a/modules/psd/layer.cpp
+++ b/modules/psd/layer.cpp
@@ -671,7 +671,8 @@ bool layer::is_explicit_dynamic() const { return (impl_->tags_ & layer_tag::expl
 bool layer::is_static() const { return (impl_->tags_ & layer_tag::rasterized) == layer_tag::rasterized; }
 bool layer::is_movable() const { return (impl_->tags_ & layer_tag::moveable) == layer_tag::moveable; }
 bool layer::is_resizable() const { return (impl_->tags_ & layer_tag::resizable) == layer_tag::resizable; }
-bool layer::is_placeholder() const { return (impl_->tags_ & layer_tag::placeholder) == layer_tag::placeholder; }
+bool layer::is_producer() const { return (impl_->tags_ & layer_tag::producer) == layer_tag::producer; }
+bool layer::is_cg_producer() const { return (impl_->tags_ & layer_tag::cg_producer) == layer_tag::cg_producer; }
 bool layer::is_cornerpin() const { return (impl_->tags_ & layer_tag::cornerpin) == layer_tag::cornerpin; }
 
 layer_tag layer::tags() const { return impl_->tags_; }

--- a/modules/psd/layer.h
+++ b/modules/psd/layer.h
@@ -161,7 +161,8 @@ public:
 	bool is_static() const;
 	bool is_movable() const;
 	bool is_resizable() const;
-	bool is_placeholder() const;
+	bool is_producer() const;
+	bool is_cg_producer() const;
 	bool is_cornerpin() const;
 	layer_tag tags() const;
 };

--- a/modules/psd/misc.cpp
+++ b/modules/psd/misc.cpp
@@ -134,8 +134,10 @@ layer_tag string_to_layer_tags(const std::wstring& str) {
 
 	layer_tag result = layer_tag::none;
 	for (auto& flag : flags) {
-		if (boost::algorithm::iequals(flag, "producer"))
-			result = result | layer_tag::placeholder;
+		if (boost::algorithm::iequals(flag, "cg"))
+			result = result | layer_tag::cg_producer;
+		else if (boost::algorithm::iequals(flag, "producer"))
+			result = result | layer_tag::producer;
 		else if (boost::algorithm::iequals(flag, "dynamic")) {
 			result = result | layer_tag::explicit_dynamic;
 			result = result & (~layer_tag::rasterized);

--- a/modules/psd/misc.h
+++ b/modules/psd/misc.h
@@ -124,12 +124,13 @@ std::wstring color_mode_to_string(color_mode c);
 
 enum class layer_tag : int {
 	none = 0,
-	placeholder = 1,
+	producer = 1,
 	explicit_dynamic = 2,
 	moveable = 4,
 	resizable = 8,
 	rasterized = 16,
-	cornerpin = 32//,
+	cornerpin = 32,
+	cg_producer = 64,
 	//all = 63
 };
 ENUM_ENABLE_BITWISE(layer_tag);

--- a/modules/psd/psd_scene_producer.cpp
+++ b/modules/psd/psd_scene_producer.cpp
@@ -467,7 +467,17 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 					break;
 				}
 
-				text_producers_by_layer_name.push_back(std::make_pair(layer_name, text_producer));
+				auto text_layer_exists = std::find_if(text_producers_by_layer_name.begin(), text_producers_by_layer_name.end(),
+					[layer_name](const std::pair<std::wstring, spl::shared_ptr<core::text_producer>>& element) { return element.first == layer_name; });
+
+				if (text_layer_exists == text_producers_by_layer_name.end())
+				{
+					text_producers_by_layer_name.push_back(std::make_pair(layer_name, text_producer));
+				}
+				else
+				{
+					CASPAR_LOG(warning) << "Found duplicate text layer name: " << layer_name;
+				}
 			}
 			else
 			{

--- a/modules/psd/psd_scene_producer.cpp
+++ b/modules/psd/psd_scene_producer.cpp
@@ -446,6 +446,7 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 	for(auto it = doc.layers().rbegin(); it != layers_end; ++it)
 	{
 		auto index = it - doc.layers().rbegin();
+		auto variable_prefix = L"layer." + boost::lexical_cast<std::wstring>(index) + L".";
 		auto& psd_layer = (*it);
 		auto& current = scene_stack.top();
 
@@ -470,7 +471,7 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 			scene_layer.hidden.set(!psd_layer->is_visible());
 
 			if (psd_layer->has_timeline())
-				create_timelines(root, dependencies.format_desc, scene_layer, psd_layer, L"TODO");
+				create_timelines(root, dependencies.format_desc, scene_layer, psd_layer, variable_prefix);
 
 			if (psd_layer->is_movable())
 				current.add(&scene_layer, psd_layer->tags(), false);
@@ -508,8 +509,6 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 			auto layer_name = psd_layer->name();
 
 			std::vector<std::pair<std::wstring, std::wstring>> cg_mappings;
-
-			auto variable_prefix = L"layer." + boost::lexical_cast<std::wstring>(index) + L".";
 
 			auto crop_x_offset = root->create_variable<double>(variable_prefix + L"crop_x_offset", false);
 
@@ -748,7 +747,7 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 		auto var = find_or_create_scene_variable<std::wstring>(root, text_layer.first);
 		text_layer.second->text().bind(var);
 	}
-	// Expose all fields reported by the cg producers
+	// Map all fields requested by the cg producers
 	for (auto& producer : cg_producers_with_mappings) {
 		auto prod = producer.first;
 		auto mappings = producer.second;

--- a/modules/psd/psd_scene_producer.cpp
+++ b/modules/psd/psd_scene_producer.cpp
@@ -507,7 +507,8 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 				text_info.scale_y = psd_layer->scale().y / max_scale;
 				text_info.shear = 0;
 
-				auto text_producer = core::text_producer::create(dependencies.frame_factory, 0, 0, str, text_info, doc.width(), doc.height());
+				const bool croppable = psd_layer->mask().has_vector() && !psd_layer->mask().vector()->rect().empty();
+				auto text_producer = core::text_producer::create(dependencies.frame_factory, 0, 0, str, text_info, doc.width(), doc.height(), false, croppable);
 				//text_producer->pixel_constraints().width.set(psd_layer->size().width);
 				//text_producer->pixel_constraints().height.set(psd_layer->size().height);
 

--- a/modules/psd/psd_scene_producer.cpp
+++ b/modules/psd/psd_scene_producer.cpp
@@ -525,7 +525,9 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 			{
 				if (psd_layer->is_placeholder())
 				{
-					auto hotswap = std::make_shared<core::hotswap_producer>(psd_layer->bitmap()->width(), psd_layer->bitmap()->height());
+					auto width = psd_layer->bitmap() ? psd_layer->bitmap()->width() : doc.width();
+					auto height = psd_layer->bitmap() ? psd_layer->bitmap()->height() : doc.height();
+					auto hotswap = std::make_shared<core::hotswap_producer>(width, height);
 
 					if (psd_layer->is_explicit_dynamic())
 					{
@@ -558,7 +560,9 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 				}
 				else if(psd_layer->is_solid())
 				{
-					layer_producer = core::create_const_producer(core::create_color_frame(it->get(), dependencies.frame_factory, psd_layer->solid_color().to_uint32()), psd_layer->bitmap()->width(), psd_layer->bitmap()->height());
+					auto width = psd_layer->bitmap() ? psd_layer->bitmap()->width() : doc.width();
+					auto height = psd_layer->bitmap() ? psd_layer->bitmap()->height() : doc.height();
+					layer_producer = core::create_const_producer(core::create_color_frame(it->get(), dependencies.frame_factory, psd_layer->solid_color().to_uint32()), width, height);
 				}
 				else if(psd_layer->bitmap())
 				{
@@ -664,7 +668,7 @@ spl::shared_ptr<core::frame_producer> create_psd_scene_producer(const core::fram
 	// Reset all dynamic text fields to empty strings and expose them as a scene parameter.
 	for (auto& text_layer : text_producers_by_layer_name) {
 		text_layer.second->text().set(L"");
-		auto var = root->create_variable<std::wstring>(boost::to_lower_copy(text_layer.first), true, L"");
+		auto var = root->create_variable<std::wstring>(text_layer.first, true, L"");
 		text_layer.second->text().bind(var);
 	}
 

--- a/modules/psd/util/pdf_reader.cpp
+++ b/modules/psd/util/pdf_reader.cpp
@@ -83,7 +83,9 @@ struct pdf_context
 	void set_name(const std::string& str)
 	{
 		name.assign(str.begin(), str.end());
+#ifdef DEBUG
 		CASPAR_LOG(debug) << get_indent() << name;
+#endif
 	}
 
 	void add_char(std::uint8_t c)
@@ -109,7 +111,9 @@ struct pdf_context
 
 	void set_value()
 	{
+#ifdef DEBUG
 		CASPAR_LOG(debug) << get_indent() << value;
+#endif
 
 		stack.back()->push_back(std::make_pair(name, Ptree(value)));
 		clear_state();

--- a/protocol/amcp/AMCPCommandQueue.cpp
+++ b/protocol/amcp/AMCPCommandQueue.cpp
@@ -59,6 +59,7 @@ exec_cmd(std::shared_ptr<AMCPCommand> cmd, const std::vector<channel_context>& c
         } catch (expected_user_error&) {
             cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
         } catch (user_error&) {
+			CASPAR_LOG_CURRENT_EXCEPTION_AT_LEVEL(debug);
             CASPAR_LOG(error) << " Check syntax. Turn on log level debug for stacktrace.";
             cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
         } catch (std::out_of_range&) {

--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <log-level>debug</log-level>
+  <thumbnails>
+    <generate-thumbnails>false</generate-thumbnails>
+  </thumbnails>
   <paths>
-    <media-path>media/</media-path>
+    <media-path>c:/caspar/_media/</media-path>
     <log-path>log/</log-path>
     <data-path>data/</data-path>
-    <template-path>template/</template-path>
+    <template-path>c:/caspar/_template/</template-path>
     <thumbnail-path>thumbnail/</thumbnail-path>
-    <font-path>font/</font-path>
+    <font-path>c:/windows/fonts/</font-path>
   </paths>
   <lock-clear-phrase>secret</lock-clear-phrase>
   <channels>


### PR DESCRIPTION
Sponsored by @didikunz and Media Support

This is some improvements for the PSD and scene producers, to fix some major bugs, make it possible to do some text masking in PSDs and allow using other cg templates inside of PSDs in a similar way to how videos can be used.

## Key changes
* PSD Text vector masks (CasparCG#1159)
* Fix PSD video playback speed in interlaced (CasparCG#625)
* Load other cg templates (flash, html etc) from PSDs
* Dynamic images and colours in scene producer (CasparCG#670)
* Add scenes/PSDs to DIAG and output some basic OSC data (CasparCG#670)
* Add system time as a scene variable with formatting options (CasparCG#670)
* Fix text rendering with large font size and unicode characters (CasparCG#670)

### Load other templates
The basic syntax is `[cg](AwayLogo>HomeLogo)HomeLogo`
This is broken down as
`[cg]` = the prefix
`(AwayLogo>HomeLogo)` = field mapping
`HomeLogo` = filename

Due to how the PSD producer works, we need to individually specify the fields to pass through. 
The mappings are structured as a list `(AwayLogo>f0,HomeLogo>f1)` and if the same name is used on both sides, then it can be used just once. eg `(HomeLogo>HomeLogo)` is the same as `(HomeLogo)`
Doing a call with new data on the psd producer will propagate the data through.

play() and stop() of the template are controlled by the first and last frame of the layer on the timeline. This means the out animation will start when the layer ends in the PSD.
