### PR TITLE
Feat/aspect ratio control

### DIFF
--- a/accelerator/ogl/image/image_kernel.cpp
+++ b/accelerator/ogl/image/image_kernel.cpp
@@ -219,8 +219,8 @@ struct image_kernel::impl
 		
 		auto const first_plane = params.pix_desc.planes.at(0);
 		if (params.geometry.mode() != core::frame_geometry::scale_mode::stretch && first_plane.width > 0 && first_plane.height > 0) {
-			auto width_scale = static_cast<float>(params.target_width) / static_cast<float>(first_plane.width);
-			auto height_scale = static_cast<float>(params.target_height) / static_cast<float>(first_plane.height);
+			auto width_scale = static_cast<double>(params.target_width) / static_cast<double>(first_plane.width);
+			auto height_scale = static_cast<double>(params.target_height) / static_cast<double>(first_plane.height);
 
 			switch (params.geometry.mode()) {
 			case core::frame_geometry::scale_mode::original:

--- a/accelerator/ogl/image/image_kernel.cpp
+++ b/accelerator/ogl/image/image_kernel.cpp
@@ -216,8 +216,24 @@ struct image_kernel::impl
 			coord.vertex_x += f_p[0];
 			coord.vertex_y += f_p[1];
 		};
+		
+		auto const first_plane = params.pix_desc.planes.at(0);
+		//CASPAR_LOG(info) << "Trying to fit " << first_plane.width << "x" << first_plane.height << " into " << params.target_width << "x" << params.target_height;
 
-		CASPAR_LOG(info) << "Trying to fit " << "x" << " into " << "x" << params.aspect_ratio;
+
+		/* Something very broken...
+		float new_aspect = static_cast<float>(params.target_width) / static_cast<float>(params.target_height);
+		float new_width = std::min(1.0f, static_cast<float>(params.target_height)* new_aspect / static_cast<float>(params.target_width));
+		float new_height = static_cast<float>(params.target_width * first_plane.width) / (static_cast<float>(params.target_height) * new_aspect);
+		*/
+
+		// Original:
+		float new_width = static_cast<float>(first_plane.width) / static_cast<float>(params.target_width);
+		float new_height = static_cast<float>(first_plane.height) / static_cast<float>(params.target_height);
+
+		f_s[0] *= new_width;
+		f_s[1] *= new_height;
+		//CASPAR_LOG(info) << "Running: " << new_width << "x" << new_height;
 
 		int corner = 0;
 		for (auto& coord : coords)

--- a/accelerator/ogl/image/image_kernel.cpp
+++ b/accelerator/ogl/image/image_kernel.cpp
@@ -217,6 +217,8 @@ struct image_kernel::impl
 			coord.vertex_y += f_p[1];
 		};
 
+		CASPAR_LOG(info) << "Trying to fit " << "x" << " into " << "x" << params.aspect_ratio;
+
 		int corner = 0;
 		for (auto& coord : coords)
 		{

--- a/accelerator/ogl/image/image_kernel.h
+++ b/accelerator/ogl/image/image_kernel.h
@@ -49,6 +49,8 @@ struct draw_params final
 	std::shared_ptr<class texture>				local_key;
 	std::shared_ptr<class texture>				layer_key;
 	double										aspect_ratio	= 1.0;
+	int											target_width;
+	int											target_height;
 };
 
 class image_kernel final

--- a/accelerator/ogl/image/image_mixer.cpp
+++ b/accelerator/ogl/image/image_mixer.cpp
@@ -157,15 +157,15 @@ private:
 			for (auto& item : layer.items)
 				draw_item(layer_texture, std::move(item), layer_key_texture, local_key_texture, local_mix_texture, format_desc);
 
-			draw_texture(layer_texture, std::move(local_mix_texture), core::blend_mode::normal);
-			draw_texture(target_texture, std::move(layer_texture), layer.blend_mode);
+			draw_texture(layer_texture, std::move(local_mix_texture), format_desc, core::blend_mode::normal);
+			draw_texture(target_texture, std::move(layer_texture), format_desc, layer.blend_mode);
 		}
 		else // fast path
 		{
 			for (auto& item : layer.items)
 				draw_item(target_texture, std::move(item), layer_key_texture, local_key_texture, local_mix_texture, format_desc);
 
-			draw_texture(target_texture, std::move(local_mix_texture), core::blend_mode::normal);
+			draw_texture(target_texture, std::move(local_mix_texture), format_desc, core::blend_mode::normal);
 		}
 
 		layer_key_texture = std::move(local_key_texture);
@@ -179,6 +179,8 @@ private:
 			  const core::video_format_desc& format_desc)
 	{
 		draw_params draw_params;
+		draw_params.target_width	= format_desc.square_width;
+		draw_params.target_height	= format_desc.square_height;
 		draw_params.pix_desc		= std::move(item.pix_desc);
 		draw_params.transform		= std::move(item.transform);
 		draw_params.geometry		= item.geometry;
@@ -212,7 +214,7 @@ private:
 		else
 		{
 			// If there is a mix, this is the end so draw it and reset
-			draw_texture(target_texture, std::move(local_mix_texture), core::blend_mode::normal);
+			draw_texture(target_texture, std::move(local_mix_texture), format_desc, core::blend_mode::normal);
 
 			draw_params.background	= target_texture;
 			draw_params.local_key	= std::move(local_key_texture);
@@ -224,12 +226,15 @@ private:
 
 	void draw_texture(const spl::shared_ptr<texture>& target_texture,
 			  const std::shared_ptr<texture>&& source_texture,
+			  const core::video_format_desc		format_desc,
 			  core::blend_mode					blend_mode = core::blend_mode::normal)
 	{
 		if(!source_texture)
 			return;
 
 		draw_params draw_params;
+		draw_params.target_width	= format_desc.square_width;
+		draw_params.target_height	= format_desc.square_height;
 		draw_params.pix_desc.format	= core::pixel_format::bgra;
 		draw_params.pix_desc.planes	= { core::pixel_format_desc::plane(source_texture->width(), source_texture->height(), 4) };
 		draw_params.textures		= { spl::make_shared_ptr(source_texture) };

--- a/accelerator/ogl/util/buffer.cpp
+++ b/accelerator/ogl/util/buffer.cpp
@@ -85,10 +85,6 @@ public:
 		(usage_ == GL_STREAM_DRAW ? g_w_total_count : g_r_total_count)	--;
 	}
 
-	void invalidate() {
-		GL(glInvalidateBufferData(pbo_));
-	}
-	
 	void bind()
 	{
 		GL(glBindBuffer(target_, pbo_));
@@ -105,7 +101,6 @@ buffer::buffer(buffer&& other) : impl_(std::move(other.impl_)){}
 buffer::~buffer(){}
 buffer& buffer::operator=(buffer&& other){impl_ = std::move(other.impl_); return *this;}
 uint8_t* buffer::data(){return impl_->data_;}
-void buffer::invalidate() const { impl_->invalidate(); }
 void buffer::bind() const { impl_->bind(); }
 void buffer::unbind() const{impl_->unbind();}
 std::size_t buffer::size() const { return impl_->size_; }

--- a/accelerator/ogl/util/buffer.h
+++ b/accelerator/ogl/util/buffer.h
@@ -53,8 +53,6 @@ public:
 
 	buffer& operator=(buffer&& other);
 
-	void invalidate() const;
-
 	void bind() const;
 	void unbind() const;
 

--- a/accelerator/ogl/util/device.cpp
+++ b/accelerator/ogl/util/device.cpp
@@ -297,7 +297,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
 					CASPAR_SCOPED_CONTEXT_MSG(context);
 					strong->texture_cache_.erase(buf.get());
 					// Clear any previous data
-					buf->invalidate();
+					// TODO - does this want to clear the buffer?
 				}, task_priority::high_priority);
 				
 				pool->push(buf);

--- a/common/memory.h
+++ b/common/memory.h
@@ -739,6 +739,12 @@ shared_ptr<T> make_shared(P0&& p0, P1&& p1, P2&& p2, P3&& p3, P4&& p4, P5&& p5, 
 	return shared_ptr<T>(std::make_shared<T>(std::forward<P0>(p0), std::forward<P1>(p1), std::forward<P2>(p2), std::forward<P3>(p3), std::forward<P4>(p4), std::forward<P5>(p5), std::forward<P6>(p6), std::forward<P7>(p7), std::forward<P8>(p8), std::forward<P9>(p9), std::forward<P10>(p10), std::forward<P11>(p11)));
 }
 
+template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8, typename P9, typename P10, typename P11, typename P12>
+shared_ptr<T> make_shared(P0&& p0, P1&& p1, P2&& p2, P3&& p3, P4&& p4, P5&& p5, P6&& p6, P7&& p7, P8&& p8, P9&& p9, P10&& p10, P11&& p11, P12&& p12)
+{
+	return shared_ptr<T>(std::make_shared<T>(std::forward<P0>(p0), std::forward<P1>(p1), std::forward<P2>(p2), std::forward<P3>(p3), std::forward<P4>(p4), std::forward<P5>(p5), std::forward<P6>(p6), std::forward<P7>(p7), std::forward<P8>(p8), std::forward<P9>(p9), std::forward<P10>(p10), std::forward<P11>(p11), std::forward<P12>(p12)));
+}
+
 template<typename T>
 shared_ptr<T>::shared_ptr() 
     : p_(make_shared<T>())

--- a/core/frame/frame_transform.h
+++ b/core/frame/frame_transform.h
@@ -100,6 +100,7 @@ struct image_transform final
 	core::field_mode		field_mode			= core::field_mode::progressive;
 	bool					is_key				= false;
         bool                                    invert                      = false;
+	// The frame is part of a 'mix'. This is a group that should be flattened and treated like a single frame?
 	bool					is_mix				= false;
 	bool					use_mipmap			= false;
 	core::blend_mode		blend_mode			= core::blend_mode::normal;

--- a/core/frame/geometry.cpp
+++ b/core/frame/geometry.cpp
@@ -46,8 +46,9 @@ bool frame_geometry::coord::operator==(const frame_geometry::coord& other) const
 
 struct frame_geometry::impl
 {
-	impl(frame_geometry::geometry_type type, std::vector<coord> data)
+	impl(frame_geometry::geometry_type type, frame_geometry::scale_mode mode, std::vector<coord> data)
 		: type_(type)
+		, mode_(mode)
 	{
 		if (type == geometry_type::quad && data.size() != 4)
 			CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("The number of coordinates needs to be 4"));
@@ -62,18 +63,20 @@ struct frame_geometry::impl
 	}
 	
 	frame_geometry::geometry_type	type_;
+	frame_geometry::scale_mode		mode_;
 	std::vector<coord>				data_;
 };
 
-frame_geometry::frame_geometry(geometry_type type, std::vector<coord> data) : impl_(new impl(type, std::move(data))) {}
+frame_geometry::frame_geometry(geometry_type type, frame_geometry::scale_mode mode, std::vector<coord> data) : impl_(new impl(type, mode, std::move(data))) {}
 
 frame_geometry::geometry_type frame_geometry::type() const { return impl_->type_; }
+frame_geometry::scale_mode frame_geometry::mode() const { return impl_->mode_; }
 const std::vector<frame_geometry::coord>& frame_geometry::data() const
 {
 	return impl_->data_;
 }
 	
-const frame_geometry& frame_geometry::get_default()
+const frame_geometry frame_geometry::get_default(frame_geometry::scale_mode mode)
 {
 	static std::vector<frame_geometry::coord> data = {
 	//    vertex    texture
@@ -82,9 +85,38 @@ const frame_geometry& frame_geometry::get_default()
 		{ 1.0, 1.0, 1.0, 1.0 }, // lower right
 		{ 0.0, 1.0, 0.0, 1.0 }  // lower left
 	};
-	static const frame_geometry g(frame_geometry::geometry_type::quad, data);
+
+	frame_geometry g(frame_geometry::geometry_type::quad, mode, data);
 
 	return g;
+}
+
+frame_geometry::scale_mode scale_mode_from_string(const std::wstring& str) {
+	if (str == L"fit") {
+		return frame_geometry::scale_mode::fit;
+	}
+	else if (str == L"fill") {
+		return frame_geometry::scale_mode::fill;
+	}
+	else if (str == L"original") {
+		return frame_geometry::scale_mode::original;
+	}
+	else {
+		return frame_geometry::scale_mode::stretch;
+	}
+}
+
+std::wstring scale_mode_to_string(frame_geometry::scale_mode mode) {
+	switch (mode) {
+	case frame_geometry::scale_mode::fill:
+		return L"FILL";
+	case frame_geometry::scale_mode::fit:
+		return L"FIT";
+	case frame_geometry::scale_mode::original:
+		return L"ORIGINAL";
+	default:
+		return L"STRETCH";
+	}
 }
 
 }}

--- a/core/frame/geometry.cpp
+++ b/core/frame/geometry.cpp
@@ -92,13 +92,14 @@ const frame_geometry frame_geometry::get_default(frame_geometry::scale_mode mode
 }
 
 frame_geometry::scale_mode scale_mode_from_string(const std::wstring& str) {
-	if (str == L"fit") {
+	auto str2 = boost::to_lower_copy(str);
+	if (str2 == L"fit") {
 		return frame_geometry::scale_mode::fit;
 	}
-	else if (str == L"fill") {
+	else if (str2 == L"fill") {
 		return frame_geometry::scale_mode::fill;
 	}
-	else if (str == L"original") {
+	else if (str2 == L"original") {
 		return frame_geometry::scale_mode::original;
 	}
 	else {

--- a/core/frame/geometry.h
+++ b/core/frame/geometry.h
@@ -36,6 +36,14 @@ public:
 		quad_list
 	};
 
+	enum class scale_mode
+	{
+		stretch, // default
+		fit,
+		fill,
+		original
+	};
+
 	struct coord
 	{
 		double vertex_x		= 0.0;
@@ -51,16 +59,20 @@ public:
 		bool operator==(const coord& other) const;
 	};
 
-	frame_geometry(geometry_type type, std::vector<coord> data);
+	frame_geometry(geometry_type type, scale_mode mode, std::vector<coord> data);
 
 	geometry_type type() const ;
+	scale_mode mode() const;
 	const std::vector<coord>& data() const;
 
-	static const frame_geometry& get_default();
+	static const frame_geometry get_default(scale_mode mode = scale_mode::stretch);
 
 private:
 	struct impl;
 	spl::shared_ptr<impl> impl_;
 };
+
+frame_geometry::scale_mode scale_mode_from_string(const std::wstring& str);
+std::wstring scale_mode_to_string(frame_geometry::scale_mode mode);
 
 }}

--- a/core/producer/text/text_producer.cpp
+++ b/core/producer/text/text_producer.cpp
@@ -201,7 +201,7 @@ public:
 		font_.set_tracking(tracking_.value().get());
 
 		auto vertex_stream = font_.create_vertex_stream(text_.value().get(), x_, y_, parent_width_, parent_height_, &metrics, shear_.value().get());
-		auto frame = atlas_frame_.with_geometry(frame_geometry(frame_geometry::geometry_type::quad_list, std::move(vertex_stream)));
+		auto frame = atlas_frame_.with_geometry(frame_geometry(frame_geometry::geometry_type::quad_list, frame_geometry::scale_mode::stretch, std::move(vertex_stream)));
 
 		this->constraints_.width.set(metrics.width * this->scale_x_.value().get());
 		this->constraints_.height.set(metrics.height * this->scale_y_.value().get());

--- a/modules/decklink/producer/decklink_producer.cpp
+++ b/modules/decklink/producer/decklink_producer.cpp
@@ -124,6 +124,7 @@ class decklink_producer
 							   format_repository_, // TODO - will this work?
                                out_format_desc_,
                                channel_layout_,
+							   core::frame_geometry::scale_mode::stretch,
                                filter_,
                                ffmpeg::filter::is_deinterlacing(filter_)};
 

--- a/modules/ffmpeg/producer/muxer/frame_muxer.h
+++ b/modules/ffmpeg/producer/muxer/frame_muxer.h
@@ -29,6 +29,7 @@
 #include <common/env.h>
 
 #include <core/frame/frame.h>
+#include <core/frame/geometry.h>
 #include <core/mixer/audio/audio_mixer.h>
 #include <core/fwd.h>
 
@@ -51,6 +52,7 @@ public:
 			const core::video_format_repository& format_repository,
 			const core::video_format_desc& format_desc,
 			const core::audio_channel_layout& channel_layout,
+			core::frame_geometry::scale_mode scale_mode,
 			const std::wstring& filter,
 			bool multithreaded_filter,
 			bool force_deinterlacing = env::properties().get(L"configuration.force-deinterlace", false));

--- a/modules/reroute/producer/channel_producer.cpp
+++ b/modules/reroute/producer/channel_producer.cpp
@@ -31,6 +31,7 @@
 #include <core/video_channel.h>
 
 #include <core/frame/frame.h>
+#include <core/frame/geometry.h>
 #include <core/frame/pixel_format.h>
 #include <core/frame/audio_channel_layout.h>
 #include <core/frame/draw_frame.h>
@@ -244,7 +245,8 @@ public:
 	explicit channel_producer(
 			const core::frame_producer_dependencies& dependecies,
 			const spl::shared_ptr<core::video_channel>& channel,
-			int frames_delay)
+			int frames_delay,
+			core::frame_geometry::scale_mode scale_mode)
 		: frame_factory_(dependecies.frame_factory)
 		, output_format_desc_(dependecies.format_desc)
 		, consumer_(spl::make_shared<channel_consumer>(frames_delay))
@@ -255,6 +257,7 @@ public:
 				dependecies.format_repository,
 				channel->video_format_desc(),
 				channel->audio_channel_layout(),
+				scale_mode,
 				L"",
 				false,
 				false)
@@ -347,9 +350,10 @@ public:
 spl::shared_ptr<core::frame_producer> create_channel_producer(
 		const core::frame_producer_dependencies& dependencies,
 		const spl::shared_ptr<core::video_channel>& channel,
-		int frames_delay)
+		int frames_delay,
+		core::frame_geometry::scale_mode scale_mode)
 {
-	auto producer = spl::make_shared<channel_producer>(dependencies, channel, frames_delay);
+	auto producer = spl::make_shared<channel_producer>(dependencies, channel, frames_delay, scale_mode);
 
 	return producer;
 }

--- a/modules/reroute/producer/channel_producer.h
+++ b/modules/reroute/producer/channel_producer.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <common/memory.h>
+#include <core/frame/geometry.h>
 
 #include <core/fwd.h>
 
@@ -30,6 +31,7 @@ namespace caspar { namespace reroute {
 spl::shared_ptr<core::frame_producer> create_channel_producer(
 		const core::frame_producer_dependencies& dependencies,
 		const spl::shared_ptr<core::video_channel>& channel,
-		int frames_delay);
+		int frames_delay,
+		core::frame_geometry::scale_mode scale_mode);
 
 }}

--- a/modules/reroute/producer/layer_producer.h
+++ b/modules/reroute/producer/layer_producer.h
@@ -25,6 +25,7 @@
 
 #include <core/fwd.h>
 #include <core/consumer/write_frame_consumer.h>
+#include <core/frame/geometry.h>
 
 namespace caspar { namespace reroute {
 
@@ -33,6 +34,7 @@ spl::shared_ptr<core::frame_producer> create_layer_producer(
 		int layer,
                 core::frame_consumer_mode mode,
 		int frames_delay,
-		const core::video_format_desc& destination_mode);
+		const core::video_format_desc& destination_mode,
+		boost::optional<core::frame_geometry::scale_mode> scale_mode);
 
 }}

--- a/modules/reroute/producer/reroute_producer.cpp
+++ b/modules/reroute/producer/reroute_producer.cpp
@@ -112,7 +112,13 @@ spl::shared_ptr<core::frame_producer> create_producer(
                 else if (contains_param(L"NEXT", params))
                     mode = core::frame_consumer_mode::next_producer;
 
-		return create_layer_producer(*found_channel, layer, mode, frames_delay, dependencies.format_desc);
+				auto scale_mode_str = get_param(L"SCALE_MODE", params, L"");
+				boost::optional<core::frame_geometry::scale_mode> scale_mode = boost::none;
+				if (scale_mode_str != L"") {
+					scale_mode = core::scale_mode_from_string(scale_mode_str);
+				}
+
+		return create_layer_producer(*found_channel, layer, mode, frames_delay, dependencies.format_desc, scale_mode);
 	}
 	else
 	{

--- a/modules/reroute/producer/reroute_producer.cpp
+++ b/modules/reroute/producer/reroute_producer.cpp
@@ -32,6 +32,7 @@
 #include <core/video_channel.h>
 #include <core/help/help_sink.h>
 #include <core/help/help_repository.h>
+#include <core/frame/geometry.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/range/algorithm/find_if.hpp>
@@ -115,7 +116,8 @@ spl::shared_ptr<core::frame_producer> create_producer(
 	}
 	else
 	{
-		return create_channel_producer(dependencies, *found_channel, frames_delay);
+		auto scale_mode = core::scale_mode_from_string(get_param(L"SCALE_MODE", params, L"stretch"));
+		return create_channel_producer(dependencies, *found_channel, frames_delay, scale_mode);
 	}
 }
 


### PR DESCRIPTION
Prototype of https://github.com/CasparCG/server/issues/673
Test build: https://drive.google.com/open?id=1FGJCvBBbcgNg1ey0KkaKj2hkv6g84X9k

This adds a new parameter to producer construction that defines how the mixer will handle scaling the layer.
eg `PLAY 1-10 AMB SCALE_MODE FIT`

The available modes are:
* STRETCH (default) - existing behaviour
* FIT - maintain aspect ratio with letterbox effect (bars are transparent)
* FILL - maintain aspect ratio, cropping to fill the screen
* ORIGINAL - don't resize the source material, play out at a 1:1 source to output pixels

It gets applied as a final transform inside the mixer, and all of the MIXER commands should continue to work just as before.

Due to the mixer transormation numbers, the resulting image by default is stuck into the top left corner. To center it, and make transforms easier it is likely that you will want to do a `MIXER 1-10 ANCHOR 0.5 0.5` and `MIXER 1-10 FILL 0.5 0.5 1 1` to make positions relative to the image midpoint, and to transform the image to the center of the channel.