### PR TITLE
Update casparcg.config with a warning

### DIFF
--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -39,6 +39,21 @@
 </configuration>
 
 <!--
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP! STOP!
+
+The configuration above is the one that CasparCG will read and use.  Below you find examples of configuration
+options that can be used in the configuration above.
+
+You can *NOT* use any of the examples below by just copy/pasting them above!
+These are examples of possible options and values for the configuration file.
+
+They are conformed as:
+<tag>default value [other possible values]</tag>
+
+Any tag in the configuration above containing brackets or multiple values will be invalid and will not work.
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 <log-level>           info  [trace|debug|info|warning|error|fatal]</log-level>
 <log-categories>      communication  [calltrace|communication|calltrace,communication]</log-categories>
 <force-deinterlace>   false  [true|false]</force-deinterlace>


### PR DESCRIPTION
An unacceptably high number of support issues are related to mishandling of the configuration file.  I hope this warning will inform users better about the config file.