### PR TITLE
Fix: ffmpeg consumer remove on error

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-CasparCG Server 2.1.0 NRK
+CasparCG Server 2.1.11 NRK
 ============================
 
 Thank you for your interest in CasparCG Server, a professional software used to

--- a/common/executor.h
+++ b/common/executor.h
@@ -249,6 +249,7 @@ private:
 		{
 			if (!is_ready(future) && is_current()) // Avoids potential deadlock.
 			{
+				// CASPAR_LOG(debug) << L"Executing function now without catch: " << name_;
 				function();
 			}
 

--- a/common/executor.h
+++ b/common/executor.h
@@ -249,7 +249,6 @@ private:
 		{
 			if (!is_ready(future) && is_current()) // Avoids potential deadlock.
 			{
-				// CASPAR_LOG(debug) << L"Executing function now without catch: " << name_;
 				function();
 			}
 

--- a/core/consumer/frame_consumer.cpp
+++ b/core/consumer/frame_consumer.cpp
@@ -34,8 +34,6 @@
 #include <boost/thread.hpp>
 
 #include <future>
-#include <thread>
-#include <chrono>
 #include <map>
 #include <vector>
 
@@ -209,27 +207,7 @@ class recover_consumer_proxy : public frame_consumer
             return consumer_->send(timecode, frame);
         } catch (...) {
             CASPAR_LOG_CURRENT_EXCEPTION();
-			// Make a future that that takes 1 second to completed
-			/* std::promise<bool> p1;
-			std::future<bool> f_completes = p1.get_future();
-			std::thread([&](std::promise<bool> p1) 
-			{
-				CASPAR_LOG(info) << L"Attempting restart in 10 seconds.";
-				std::this_thread::sleep_for(std::chrono::seconds(10));
-				try {
-					consumer_->initialize(format_desc_, channel_layout_, channel_index_);
-					consumer_->send(timecode, frame);
-					p1.set_value_at_thread_exit(true);
-				}
-				catch (...) {
-					CASPAR_LOG_CURRENT_EXCEPTION();
-					CASPAR_LOG(error) << print() << " Failed to recover consumer.";
-					p1.set_value_at_thread_exit(false);
-				}
-			}, std::move(p1)).detach();
-
-			return f_completes; */
-			try {
+			try { // Note: following line will always fail for FFmpeg consumer
 				consumer_->initialize(format_desc_, channel_layout_, channel_index_);
 				return consumer_->send(timecode, frame);
 			}

--- a/core/consumer/frame_consumer.cpp
+++ b/core/consumer/frame_consumer.cpp
@@ -34,6 +34,8 @@
 #include <boost/thread.hpp>
 
 #include <future>
+#include <thread>
+#include <chrono>
 #include <map>
 #include <vector>
 
@@ -207,14 +209,35 @@ class recover_consumer_proxy : public frame_consumer
             return consumer_->send(timecode, frame);
         } catch (...) {
             CASPAR_LOG_CURRENT_EXCEPTION();
-            try {
-                consumer_->initialize(format_desc_, channel_layout_, channel_index_);
-                return consumer_->send(timecode, frame);
-            } catch (...) {
-                CASPAR_LOG_CURRENT_EXCEPTION();
-                CASPAR_LOG(error) << print() << " Failed to recover consumer.";
-                return make_ready_future(false);
-            }
+			// Make a future that that takes 1 second to completed
+			/* std::promise<bool> p1;
+			std::future<bool> f_completes = p1.get_future();
+			std::thread([&](std::promise<bool> p1) 
+			{
+				CASPAR_LOG(info) << L"Attempting restart in 10 seconds.";
+				std::this_thread::sleep_for(std::chrono::seconds(10));
+				try {
+					consumer_->initialize(format_desc_, channel_layout_, channel_index_);
+					consumer_->send(timecode, frame);
+					p1.set_value_at_thread_exit(true);
+				}
+				catch (...) {
+					CASPAR_LOG_CURRENT_EXCEPTION();
+					CASPAR_LOG(error) << print() << " Failed to recover consumer.";
+					p1.set_value_at_thread_exit(false);
+				}
+			}, std::move(p1)).detach();
+
+			return f_completes; */
+			try {
+				consumer_->initialize(format_desc_, channel_layout_, channel_index_);
+				return consumer_->send(timecode, frame);
+			}
+			catch (...) {
+				CASPAR_LOG_CURRENT_EXCEPTION();
+				CASPAR_LOG(error) << print() << " Failed to recover consumer.";
+				return make_ready_future(false);
+			}
         }
     }
 

--- a/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -447,7 +447,7 @@ public:
 
 				if (!(oc_->oformat->flags & AVFMT_NOFILE))
 				{
-					CASPAR_LOG(info) << L"Caspar is opening file, not demuxer.";
+					CASPAR_LOG(debug) << L"Caspar is opening output with avio_open2, not the FFmpeg demuxer.";
 					FF(avio_open2(
 						&oc_->pb,
 						full_path_.string().c_str(),
@@ -1245,9 +1245,6 @@ public:
 
         void create_consumers()
 	{
-			// if (consumer_) {
-			// 	delete consumer_.release();
-			// }
 			if (consumer_)
 				CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Cannot reinitialize ffmpeg-consumer."));
 

--- a/modules/ffmpeg/ffmpeg_error.cpp
+++ b/modules/ffmpeg/ffmpeg_error.cpp
@@ -49,8 +49,6 @@ void throw_on_ffmpeg_error(int ret, const char* source, const char* func, const 
 		return;
 	}
 
-	// CASPAR_LOG(debug) << L"Received interleaved error code " << ret;
-
 	switch(ret)
 	{
 	case AVERROR_BSF_NOT_FOUND:

--- a/modules/ffmpeg/ffmpeg_error.cpp
+++ b/modules/ffmpeg/ffmpeg_error.cpp
@@ -45,8 +45,11 @@ std::string av_error_str(int errn)
 
 void throw_on_ffmpeg_error(int ret, const char* source, const char* func, const char* local_func, const char* file, int line)
 {
-	if(ret >= 0)
+	if (ret >= 0) {
 		return;
+	}
+
+	// CASPAR_LOG(debug) << L"Received interleaved error code " << ret;
 
 	switch(ret)
 	{

--- a/version.tmpl
+++ b/version.tmpl
@@ -1,6 +1,6 @@
 #define CASPAR_GEN 2
 #define CASPAR_MAYOR 1
-#define CASPAR_MINOR 0
+#define CASPAR_MINOR 11
 #define CASPAR_TAG "NRK"
 #define CASPAR_REV ${GIT_REV}
 #define CASPAR_HASH "${GIT_HASH}"


### PR DESCRIPTION
When an error occurs during writing or streaming using the FFmpeg consumer, errors from FFmpeg are not reported and CasparCG continues as if no problem has occurred - no warnings, no attempt to handle the issue.

This pull requests exposes FFmpeg errors that occur during the demuxing process that could include network or file system errors. These are thrown as exceptions and set the consumer into a state where on the next frame send, the consumer itself throws and exception, causing the consumer to be stopped (uninitialized).

Note that automatic restarting of the consumer is attempted but this fails due to code in the consumer designed to stop this from happenning.