### PR TITLE
Fix audio blip on load command

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-CasparCG Server 2.1.0 NRK
+CasparCG Server 2.1.9 NRK
 ============================
 
 Thank you for your interest in CasparCG Server, a professional software used to

--- a/core/producer/frame_producer.cpp
+++ b/core/producer/frame_producer.cpp
@@ -131,8 +131,9 @@ struct frame_producer_base::impl
         if (first_frame_ == draw_frame::empty())
             first_frame_ = draw_frame::push(frame);
 
-        return last_frame_ = draw_frame::push(frame);
-    }
+		last_frame_ = draw_frame::push(frame);
+		return paused_ ? draw_frame::still(last_frame_) : last_frame_;
+	}
 
     draw_frame first_frame()
     {

--- a/version.tmpl
+++ b/version.tmpl
@@ -1,6 +1,6 @@
 #define CASPAR_GEN 2
 #define CASPAR_MAYOR 1
-#define CASPAR_MINOR 0
+#define CASPAR_MINOR 9
 #define CASPAR_TAG "NRK"
 #define CASPAR_REV ${GIT_REV}
 #define CASPAR_HASH "${GIT_HASH}"


### PR DESCRIPTION
The LOAD command causes the first frame to be fetched from the source. By design this is delivered to the channel with the audio set to be silent. On one code path used when the frame is first available the audio was delivered without setting it to be silent.