### PR TITLE
Convert system path to URL for flash producer

### DIFF
--- a/modules/flash/producer/flash_producer.cpp
+++ b/modules/flash/producer/flash_producer.cpp
@@ -21,6 +21,10 @@
 
 #include "../stdafx.h"
 
+#include "WinInet.h"
+#include "shlwapi.h"
+#include "winerror.h"
+
 #if defined(_MSC_VER)
 #pragma warning (disable : 4146)
 #pragma warning (disable : 4244)
@@ -617,16 +621,33 @@ public:
 	}
 };
 
+std::wstring url_from_path(std::wstring in)
+{
+	DWORD        out_length = INTERNET_MAX_URL_LENGTH * 2 + 4;
+	PWSTR        out_buf = (PWSTR)malloc(out_length);
+	HRESULT      ret = UrlCreateFromPathW(in.c_str(), out_buf, &out_length, NULL);
+	std::wstring out;
+	if (SUCCEEDED(ret)) {
+		out = out_buf;
+		free(out_buf);
+		return out;
+	}
+	else {
+		free(out_buf);
+		return in;
+	}
+}
+
 spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params)
 {
 	auto template_host = get_template_host(dependencies.format_desc);
 	
-	auto filename = env::template_folder() + L"\\" + template_host.filename;
+	auto filename = env::template_folder() + template_host.filename;
 	
 	if(!boost::filesystem::exists(filename))
 		CASPAR_THROW_EXCEPTION(file_not_found() << msg_info(L"Could not open flash movie " + filename));	
 
-	return create_destroy_proxy(spl::make_shared<flash_producer>(dependencies.frame_factory, dependencies.format_desc, filename, template_host.width, template_host.height));
+	return create_destroy_proxy(spl::make_shared<flash_producer>(dependencies.frame_factory, dependencies.format_desc, url_from_path(filename), template_host.width, template_host.height));
 }
 
 void describe_swf_producer(core::help_sink& sink, const core::help_repository& repo)
@@ -640,7 +661,7 @@ void describe_swf_producer(core::help_sink& sink, const core::help_repository& r
 
 spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params)
 {
-	auto filename = env::media_folder() + L"\\" + params.at(0) + L".swf";
+	auto filename = env::media_folder() + params.at(0) + L".swf";
 
 	if (!boost::filesystem::exists(filename))
 		return core::frame_producer::empty();
@@ -648,7 +669,7 @@ spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_prod
 	swf_t::header_t header(filename);
 
 	auto producer = spl::make_shared<flash_producer>(
-			dependencies.frame_factory, dependencies.format_desc, filename, header.frame_width, header.frame_height);
+			dependencies.frame_factory, dependencies.format_desc, url_from_path(filename), header.frame_width, header.frame_height);
 
 	producer->call({ L"start_rendering" }).get();
 
@@ -658,13 +679,13 @@ spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_prod
 std::wstring find_template(const std::wstring& template_name)
 {
 	if(boost::filesystem::exists(template_name + L".ft")) 
-		return template_name + L".ft";
+		return url_from_path(template_name + L".ft");
 	
 	if(boost::filesystem::exists(template_name + L".ct"))
-		return template_name + L".ct";
+		return url_from_path(template_name + L".ct");
 	
 	if(boost::filesystem::exists(template_name + L".swf"))
-		return template_name + L".swf";
+		return url_from_path(template_name + L".swf");
 
 	return L"";
 }


### PR DESCRIPTION
This converts the system path to a url required for use with flash when whitelisting. 